### PR TITLE
Added new tag `access-record` for the `coming soon` example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext {
                     'name'   : 'C#',
                     'version': '1.0.0-RC2',
                     'gitref' : '1.0',
-                    'url'    : 'PLACEHOLDER_FOR_REPOSITORY_CONTAINING_THE_RELEASED_DOT_NET_DRIVER_ARTIFACT'
+                    'url'    : 'https://www.nuget.org/packages/Neo4j.Driver'
             ],
             'java': [
                     'name'   : 'Java',

--- a/src/main/asciidoc/result/index.adoc
+++ b/src/main/asciidoc/result/index.adoc
@@ -95,7 +95,7 @@ As the fields are both keyed and ordered, the value of a field can be accessed e
 --
 [source, csharp]
 ----
-COMING SOON
+include::{dotnet-examples}/Examples.cs[tags=access-record]
 ----
 --
 
@@ -103,7 +103,7 @@ COMING SOON
 --
 [source, java]
 ----
-COMING SOON
+include::{java-examples}/Examples.java[tags=access-record]
 ----
 --
 
@@ -111,7 +111,7 @@ COMING SOON
 --
 [source, javascript]
 ----
-COMING SOON
+include::{javascript-examples}/examples.test.js[tags=access-record]
 ----
 --
 
@@ -119,7 +119,7 @@ COMING SOON
 --
 [source, python]
 ----
-COMING SOON
+include::{python-examples}/test_examples.py[tag=access-record]
 ----
 --
 ====
@@ -191,7 +191,7 @@ include::{java-examples}/Examples.java[tags=nested-statements]
 --
 [source, javascript]
 ----
-include::{javascript-examples}/examples.test.js[tags=retain-result-query]
+include::{javascript-examples}/examples.test.js[tags=nested-statement]
 ----
 --
 [include-with-python]


### PR DESCRIPTION
The js driver will soon have the tag `tags=nested-statement` so change it in advance a bit
