### PR TITLE
spelling: javascript

### DIFF
--- a/src/main/asciidoc/client-applications.adoc
+++ b/src/main/asciidoc/client-applications.adoc
@@ -475,7 +475,7 @@ include::{java-examples}/ConfigConnectionTimeoutExample.java[tags=config-connect
 ======
 [source, javascript]
 ----
-This feature is not available in the Javascript driver.
+This feature is not available in the JavaScript driver.
 ----
 ======
 


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`