### PR TITLE
Complete missing sections about Go Driver

### DIFF
--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -527,6 +527,14 @@ include::{dotnet-examples}/Examples.cs[tags=config-connection-pool]
 ----
 ======
 
+[.include-with-go]
+======
+[source, go]
+----
+include::{go-examples}/examples_test.go[tags=config-connection-pool]
+----
+======
+
 [.include-with-java]
 ======
 [source, java]
@@ -567,6 +575,14 @@ For example:
 [source, csharp]
 ----
 include::{dotnet-examples}/Examples.cs[tags=config-connection-timeout]
+----
+======
+
+[.include-with-go]
+======
+[source, go]
+----
+include::{go-examples}/examples_test.go[tags=config-connection-timeout]
 ----
 ======
 

--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -596,51 +596,6 @@ include::{python-examples}/config_connection_timeout_example.py[tags=config-conn
 ====
 
 
-[[driver-load-balancing-strategy]]
-=== Load balancing strategy
-
-A routing driver contains a load balancer to route queries evenly among many cluster members.
-The built-in load balancer provides two strategies: `least-connected` and `round-robin`.
-The `least-connected` strategy in general gives a better performance as it takes query execution time and server load into consideration when distributing queries among the cluster members.
-Default value: `least-connected`.
-
-[.tabbed-example]
-.Load balancing strategy
-====
-[.include-with-dotnet]
-======
-[source, csharp]
-----
-include::{dotnet-examples}/Examples.cs[tags=config-load-balancing-strategy]
-----
-======
-
-[.include-with-java]
-======
-[source, java]
-----
-include::{java-examples}/ConfigLoadBalancingStrategyExample.java[tags=config-load-balancing-strategy]
-----
-======
-
-[.include-with-javascript]
-======
-[source, javascript]
-----
-include::{javascript-examples}/examples.test.js[tags=config-load-balancing-strategy]
-----
-======
-
-[.include-with-python]
-======
-[source, python]
-----
-include::{python-examples}/config_load_balancing_strategy_example.py[tags=config-load-balancing-strategy]
-----
-======
-====
-
-
 [[driver-configuration-max-retry-time]]
 === Max retry time
 

--- a/asciidoc/get-started.adoc
+++ b/asciidoc/get-started.adoc
@@ -27,7 +27,7 @@ The following languages and frameworks are officially supported by Neo4j:
 [deprecated]#Note that Python 2 support is deprecated and will be discontinued in the 2.x series drivers.#
 | JavaScript         | All LTS versions of Node.JS, specifically the 4.x and 6.x series runtimes (https://github.com/nodejs/LTS).
 | .NET               | .NET standard 1.3 (https://github.com/dotnet/standard/blob/master/docs/versions.md) and .NET 4.5.2 and above.
-| Go                 | 1.10 and above.
+| Go                 | Go 1.10, 1.11 (latest patch releases).
 |===
 
 The driver API is intended to be topologically agnostic.
@@ -85,6 +85,51 @@ PM> Install-Package Neo4j.Driver -Version {dotnet-driver-version}
 ========
 
 You can review the release notes for this driver https://github.com/neo4j/neo4j-dotnet-driver/releases[here].
+
+======
+
+[.include-with-go]
+======
+
+To find out the latest version of the driver, visit https://github.com/neo4j/neo4j-go-driver/releases.
+
+In order to get go driver running, you need to install our C connector, seabolt, on your build and production environments.
+Follow instructions at https://github.com/neo4j-drivers/seabolt for installing seabolt through one of our binary packages or by building from scratch.
+
+The go driver makes use of `cgo` and `pkg-config` to build against `seabolt` and thus requires a working `cgo` and `pkg-config` environment on your build environment.
+
+========
+
+To install the latest version of the driver using `go get`:
+
+[source, shell, subs="attributes, specialcharacters"]
+----
+go get github.com/neo4j/neo4j-go-driver
+----
+
+========
+
+========
+
+To install the latest version of the driver using `dep`:
+
+[source, shell, subs="attributes, specialcharacters"]
+----
+dep ensure github.com/neo4j/neo4j-go-driver
+----
+
+You can also choose to install a certain version of the driver.
+Below is the syntax for using a certain minor version of the driver. 
+Visit https://golang.github.io/dep/docs/Gopkg.toml.html#version-rules for a detailed description of version rules that can be used.
+
+[source, shell, subs="attributes, specialcharacters"]
+----
+dep ensure github.com/neo4j/neo4j-go-driver@1.7.x
+----
+
+========
+
+You can review the release notes for this driver https://github.com/neo4j/neo4j-go-driver/releases[here].
 
 ======
 
@@ -288,6 +333,11 @@ For a comprehensive listing of all driver functionality, refer to the API docume
 [.include-with-dotnet]
 ======
 {api-docs-base-uri}/dotnet-driver/{dotnet-driver-apidoc-version}/
+======
+
+[.include-with-go]
+======
+{api-docs-base-uri}/go-driver/{go-driver-apidoc-version}/
 ======
 
 [.include-with-java]

--- a/asciidoc/working-with-cypher-values.adoc
+++ b/asciidoc/working-with-cypher-values.adoc
@@ -84,6 +84,34 @@ Custom types (those not available in the language or standard library) are highl
 Inbound conversion is carried out using http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping[Extended Windows-Olson zid mapping] as defined by Unicode CLDR.
 ======
 
+[.include-with-go]
+======
+[options="header", cols="m,"]
+|===
+| Neo4j type        | Go type
+| null | `null`
+| List | `[]interface{}`
+| Map | `map[string]interface{}`
+| Boolean | `bool`
+| Integer | `int64`
+| Float | `float64`
+| String | `string`
+| ByteArray | `[]byte`
+| Date | *`neo4j.Date`*
+| Time | *`neo4j.OffsetTime`*
+| LocalTime | *`neo4j.LocalTime`*
+| DateTime | *`time.Time`**
+| LocalDateTime | *`neo4j.LocalDateTime`*
+| Duration | *`neo4j.Duration`*
+| Point | *`neo4j.Point`*
+| Node | *`neo4j.Node`*
+| Relationship | *`neo4j.Relationship`*
+| Path | *`neo4j.Path`*
+|===
+
++*+ When a `time.Time` value is sent/received through the driver and its `Zone()` returns a name of `Offset`, the value is stored with its offset value rather than its zone name.
+======
+
 [.include-with-java]
 ======
 [options="header", cols="m,"]


### PR DESCRIPTION
This PR completes all missing sections about Go Driver. The new sample code is already merged in [1.7-dev](https://github.com/neo4j/neo4j-go-driver/tree/1.7-dev) branch of go driver repository.