### PR TITLE
Update Go API Doc page

### DIFF
--- a/asciidoc/get-started.adoc
+++ b/asciidoc/get-started.adoc
@@ -337,7 +337,7 @@ For a comprehensive listing of all driver functionality, refer to the API docume
 
 [.include-with-go]
 ======
-{api-docs-base-uri}/go-driver/{go-driver-apidoc-version}/
+https://godoc.org/github.com/neo4j/neo4j-go-driver/neo4j
 ======
 
 [.include-with-java]


### PR DESCRIPTION
This PR updates Go API Doc's to point https://godoc.org/github.com/neo4j/neo4j-go-driver/neo4j.