### PR TITLE
Fix cypher type mapping table

### DIFF
--- a/asciidoc/working-with-cypher-values.adoc
+++ b/asciidoc/working-with-cypher-values.adoc
@@ -89,7 +89,7 @@ Inbound conversion is carried out using http://cldr.unicode.org/development/deve
 [options="header", cols="m,"]
 |===
 | Neo4j type        | Go type
-| null | `null`
+| null | `nil`
 | List | `[]interface{}`
 | Map | `map[string]interface{}`
 | Boolean | `bool`


### PR DESCRIPTION
This PR fixes Go type mapping table in '4.1. The Cypher type system' to denote `nil` instead of `null`, an issue raised by https://github.com/neo4j/neo4j-go-driver/issues/43.