### PR TITLE
Fix note

### DIFF
--- a/asciidoc/sessions-and-transactions.adoc
+++ b/asciidoc/sessions-and-transactions.adoc
@@ -268,6 +268,12 @@ Each bookmark records a point in transactional history and can be used to inform
 Internally, a bookmark is passed from server to client on successful completion of a transaction and back from client to server on start of a new transaction, even if the transaction is an <<driver-transactions-auto-commit, auto-commit transaction>>.
 On receipt of one or more bookmarks, the transaction will block until the server has fast forwarded to catch up with the latest of these.
 
+[NOTE]
+--
+If you use the {driver-version} driver to connect to a Neo4j database that is version 3.4 or earlier, <<driver-transactions-auto-commit, auto-commit transactions>> cannot take part in the causal chain.
+In that configuration, session.run calls should be avoided in places where causal consistency is important.
+--
+
 Within a session, bookmark propagation is carried out automatically and does not require any explicit signal or setting from the application.
 To opt out of this mechanism for unrelated units of work, applications can use multiple sessions.
 This avoids the small latency overhead of the causal chain.

--- a/asciidoc/sessions-and-transactions.adoc
+++ b/asciidoc/sessions-and-transactions.adoc
@@ -263,16 +263,10 @@ When working with a Causal Cluster, transactions can be chained to ensure causal
 This means that for any two transactions, it is guaranteed that the second transaction will begin only after the first has been successfully committed.
 This is true even if the transactions are carried out on different physical cluster members.
 
-[NOTE]
---
-Due to protocol limitations, <<driver-transactions-auto-commit, auto-commit transactions>> cannot currently take part in the causal chain.
-While this is expected to change in a future protocol release, `session.run` calls should be avoided in places where causal consistency is important.
---
-
 Causal chaining is carried out by passing <<term-bookmark, bookmarks>> between transactions.
 Each bookmark records a point in transactional history and can be used to inform cluster members to carry out units of work in a particular sequence.
-Internally, a bookmark is passed from server to client on a successful COMMIT and back from client to server on BEGIN.
-On receipt of one or more bookmarks, the transaction server will block until it has fast forwarded to catch up with the latest of these.
+Internally, a bookmark is passed from server to client on successful completion of a transaction and back from client to server on start of a new transaction, even if the transaction is an <<driver-transactions-auto-commit, auto-commit transaction>>.
+On receipt of one or more bookmarks, the transaction will block until the server has fast forwarded to catch up with the latest of these.
 
 Within a session, bookmark propagation is carried out automatically and does not require any explicit signal or setting from the application.
 To opt out of this mechanism for unrelated units of work, applications can use multiple sessions.


### PR DESCRIPTION
The PR removes a note which is no more correct since drivers 1.7 and server 3.5. Not sure whether we should highlight that the new behaviour is only valid when using 1.7 driver against a 3.5+ server?