### PR TITLE
First pass at adding copy-to-clipboard functionality

### DIFF
--- a/css/chunked-base.css
+++ b/css/chunked-base.css
@@ -239,14 +239,6 @@ h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, h4 > a.link:hover, h5 >
  * END Tide over until github
  */
 
- .copy-to-clipboard {
-  vertical-align: top;
-  cursor: pointer;
-  top: 0.325rem;
-  right: 0.325rem;
-  position: absolute;
-}
-
 .programlisting { position: relative; }
 .programlisting code[data-lang]:before {
     display: none;
@@ -254,7 +246,7 @@ h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, h4 > a.link:hover, h5 >
     position: absolute;
     font-size: 0.8em;
     top: 0.425rem;
-    right: 0.5rem;
+    right: 1.3rem;
     line-height: 1;
     text-transform: uppercase;
     color: #999;
@@ -262,6 +254,24 @@ h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, h4 > a.link:hover, h5 >
 
 .programlisting:hover code[data-lang]:before {
     display: block;
+}
+
+.programlisting .copy-to-clipboard {
+  display: none;
+  position: absolute;
+  vertical-align: top;
+  cursor: pointer;
+  top: 0.325rem;
+  right: 0.325rem;
+  color: #999;
+}
+
+.programlisting:hover .copy-to-clipboard {
+    display: block;
+}
+
+.copy-to-clipboard:hover {
+    color: #000;
 }
 
 div.toc ul {

--- a/css/chunked-base.css
+++ b/css/chunked-base.css
@@ -239,6 +239,14 @@ h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, h4 > a.link:hover, h5 >
  * END Tide over until github
  */
 
+ .copy-to-clipboard {
+  vertical-align: top;
+  cursor: pointer;
+  top: 0.325rem;
+  right: 0.325rem;
+  position: absolute;
+}
+
 .programlisting { position: relative; }
 .programlisting code[data-lang]:before {
     display: none;

--- a/javascript/tabs-for-chunked.js
+++ b/javascript/tabs-for-chunked.js
@@ -1,3 +1,26 @@
+function copyToClipboardBind() {
+    var onClick = function copyToClipboardOnClick(element) {
+        var $temp = $("<textarea>");
+        $("body").append($temp);
+        text = element
+            .parent()
+            .text()
+            .replace("PM>", "");
+        $temp.val(text).select();
+        document.execCommand("copy");
+        $temp.remove();
+    };
+    elems = $($("code"));
+    elems.each(function(i, elem) {
+        elem = $(elem);
+        text = elem.text();
+        elem.append("<i class='copy fa fa-copy' />");
+        elem.find("i").click(function() {
+            onClick($(this));
+        });
+    });
+}
+
 function tabTheSource($content) {
     var LANGUAGES = {
         'dotnet': 'C#',

--- a/javascript/tabs-for-chunked.js
+++ b/javascript/tabs-for-chunked.js
@@ -14,7 +14,7 @@ function copyToClipboardBind() {
     elems.each(function(i, elem) {
         elem = $(elem);
         text = elem.text();
-        elem.append("<i class='copy fa fa-copy' />");
+        elem.append("<i class='copy-to-clipboard fa fa-copy' />");
         elem.find("i").click(function() {
             onClick($(this));
         });
@@ -140,6 +140,7 @@ function tabTheSource($content) {
         $exampleBlock.children('div.example-title', this).first().after($ul);
         $exampleBlock.append($wrapper);
     }
+    copyToClipboardBind();
 }
 
 function storageAvailable(type) {


### PR DESCRIPTION
Adds copy-to-clipboard functionality to code snippets

![copy-to-paste](https://user-images.githubusercontent.com/849508/54363979-f35a5180-4663-11e9-874b-6fe769fbb86d.gif)

Note: removes the code snippet language text on hover