### PR TITLE
Add meta tag to prioritize web search of docs over community pages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ plugins {
     id 'de.undercouch.download' version '3.2.0'
     id 'org.neo4j.doc.build.vale' version '1.0-alpha01'
     id 'org.neo4j.doc.build.saxon' version '1.0-alpha01'
-    id 'org.neo4j.doc.build.docbook' version '1.0-alpha09'
+    id 'org.neo4j.doc.build.docbook' version '1.0-alpha11'
     id 'maven-publish'
 }
 


### PR DESCRIPTION
This PR updates the reference to a documentation plugin.
The actual change happens in neo-technology/documentation-gradle-plugins#2