### PR TITLE
Add javascript sample for connection timeout

### DIFF
--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -601,7 +601,7 @@ include::{java-examples}/ConfigConnectionTimeoutExample.java[tags=config-connect
 ======
 [source, javascript]
 ----
-This feature is not available in the JavaScript driver.
+include::{javascript-examples}/examples.test.js[tags=config-connection-timeout]
 ----
 ======
 


### PR DESCRIPTION
The example listing did not contain a javascript sample for connection timeout configuration, but was saying that the feature is not available in javascript driver. 

This PR fixes this by adding the correct reference for example code.