### PR TITLE
Add a table which illustrates the encryption and trust settings needed for different versions

### DIFF
--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -366,6 +366,12 @@ include::{python-examples}/custom_auth_example.py[tags=custom-auth]
 === Encryption
 
 TLS encryption is enabled for all connections by default.
+
+[NOTE]
+====
+Please note that if you are using a Neo4j driver with Neo4j Aura, you must have encryption set to on.
+====
+
 This can be disabled through configuration as follows:
 
 [.tabbed-example]

--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -369,10 +369,10 @@ TLS encryption is enabled for all connections by default.
 
 [NOTE]
 ====
-Please note that if you are using a Neo4j driver with Neo4j Aura, you must have encryption set to on.
+Please note that if you are using a Neo4j driver with Neo4j Aura, in addition to the default value of enabled encryption, you must also enable `TRUST_SYSTEM_CA_SIGNED_CERTIFICATES`.
 ====
 
-This can be disabled through configuration as follows:
+You can disable encryption through configuration, as follows:
 
 [.tabbed-example]
 .Unencrypted

--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -367,10 +367,21 @@ include::{python-examples}/custom_auth_example.py[tags=custom-auth]
 
 TLS encryption is enabled for all connections by default.
 
-[NOTE]
-====
-Please note that if you are using a Neo4j driver with Neo4j Aura, in addition to the default value of enabled encryption, you must also enable `TRUST_SYSTEM_CA_SIGNED_CERTIFICATES`.
-====
+
+If you are using a Neo4j driver with Neo4j Aura, in addition to the default value of enabled encryption, you must also enable `TRUST_SYSTEM_CA_SIGNED_CERTIFICATES`.
+
+.Examples of required encryption and trust settings:
+[cols="1h,1m"]
+|===
+|Neo4j 3.x
+|GraphDatabase.driver("bolt://graph.example.com:7687")
+
+|Neo4j 4.x
+|GraphDatabase.driver("bolt://graph.example.com:7687", encrypted=False)
+
+|Neo4j Aura
+|GraphDatabase.driver("neo4j://graph.example.com:7687", trust=TRUST_SYSTEM_CA_SIGNED_CERTIFICATES)
+|===
 
 You can disable encryption through configuration, as follows:
 

--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -367,7 +367,6 @@ include::{python-examples}/custom_auth_example.py[tags=custom-auth]
 
 TLS encryption is enabled for all connections by default.
 
-
 If you are using a Neo4j driver with Neo4j Aura, in addition to the default value of enabled encryption, you must also enable `TRUST_SYSTEM_CA_SIGNED_CERTIFICATES`.
 
 .Examples of required encryption and trust settings:


### PR DESCRIPTION
The contents of this table, and the preceding text, need to be changed when forward merging to v4.0:

Neo4j 3.x | `GraphDatabase.driver("neo4j://graph.example.com:7687", encrypted=True, trust=TRUST_ALL_CERTIFICATES)`
Neo4j 4.x | `GraphDatabase.driver("neo4j://graph.example.com:7687")`
Neo4j Aura | `GraphDatabase.driver("neo4j://graph.example.com:7687", encrypted=True)`
