### PR TITLE
Add documentation for database selection.

### DIFF
--- a/asciidoc/cypher-workflow.adoc
+++ b/asciidoc/cypher-workflow.adoc
@@ -274,20 +274,22 @@ Some administrative operations must be carried out against the `system` database
 To do this, construct a session targeting the database called `system` and execute Cypher as usual.
 Please see <<cypher-manual#administration-databases-introduction, Cypher Manual -> Databases>> for more information.
 
+
 [role=enterprise-edition]
 [[database-selection]]
 === Database selection
 
 The database selection on the client side happens on the <<driver-session-api, session API>>.
+
 You pass the name of the database to the driver during session creation.
-The default database is used if you don't specify a name.
-A database name must not be literal `null` nor an empty string.
+If you don't specify a name, the default database is used.
+The database name must not be `null`, nor an empty string.
 
-NOTE: Selection of database is only possible when the driver is connected against Enterprise Edition of Neo4j.
-      Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
+[NOTE]
+The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition.
+Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-
-The database that is requested must exist.
+Please note that the database that is requested must exist.
 
 [.tabbed-example]
 .Database selection on session creation

--- a/asciidoc/cypher-workflow.adoc
+++ b/asciidoc/cypher-workflow.adoc
@@ -274,6 +274,58 @@ Some administrative operations must be carried out against the `system` database
 To do this, construct a session targeting the database called `system` and execute Cypher as usual.
 Please see <<cypher-manual#administration-databases-introduction, Cypher Manual -> Databases>> for more information.
 
+[role=enterprise-edition]
+[[database-selection]]
+=== Database selection
+
+The database selection on the client side happens on the <<driver-session-api>>.
+You pass the name of the database to the driver during session creation.
+The default database is used if you don't specify a name.
+A database name must not be literal `null` nor an empty string.
+
+NOTE: While there are no different versions of the driver for the community or enterprise edition of Neo4j, those methods
+      will only work when the driver is connected against the enterprise edition of Neo4j.
+
+The database that is requested must exist.
+
+[.tabbed-example]
+.Database selection on session creation
+====
+[.include-with-dotnet]
+======
+.Database selection on session creation
+[source, csharp]
+----
+include::{dotnet-examples}/Examples.cs[tags=database-selection]
+----
+======
+
+[.include-with-java]
+======
+.Database selection on session creation
+[source, java]
+----
+include::{java-examples}/DatabaseSelectionExample.java[tags=database-selection]
+----
+
+.Import database selection on session creation
+[source, java]
+----
+include::{java-examples}/DatabaseSelectionExample.java[tags=database-selection-import]
+----
+======
+
+[.include-with-javascript]
+======
+.Read write transaction
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=database-selection]
+----
+======
+
+====
+
 [[driver-type-mapping]]
 == Type mapping
 

--- a/asciidoc/cypher-workflow.adoc
+++ b/asciidoc/cypher-workflow.adoc
@@ -283,8 +283,9 @@ You pass the name of the database to the driver during session creation.
 The default database is used if you don't specify a name.
 A database name must not be literal `null` nor an empty string.
 
-NOTE: While there are no different versions of the driver for the community or enterprise edition of Neo4j, those methods
-      will only work when the driver is connected against the enterprise edition of Neo4j.
+NOTE: Selection of database is only possible when the driver is connected against Enterprise Edition of Neo4j.
+      Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
+
 
 The database that is requested must exist.
 

--- a/asciidoc/cypher-workflow.adoc
+++ b/asciidoc/cypher-workflow.adoc
@@ -278,7 +278,7 @@ Please see <<cypher-manual#administration-databases-introduction, Cypher Manual 
 [[database-selection]]
 === Database selection
 
-The database selection on the client side happens on the <<driver-session-api>>.
+The database selection on the client side happens on the <<driver-session-api, session API>>.
 You pass the name of the database to the driver during session creation.
 The default database is used if you don't specify a name.
 A database name must not be literal `null` nor an empty string.


### PR DESCRIPTION
This is for 4.0.1 and it describes how to select a database.

As this is an enterprise only feature, I have tagged it as such. Please review if it renders with the "Enterprise"-badge. Thanks.