### PR TITLE
Switch examples so import comes first

### DIFF
--- a/asciidoc/client-applications.adoc
+++ b/asciidoc/client-applications.adoc
@@ -68,16 +68,17 @@ include::{dotnet-examples}/Examples.cs[tags=driver-lifecycle]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/DriverLifecycleExample.java[tags=driver-lifecycle]
-----
-
 .Import driver lifecycle
 [source, java]
 ----
 include::{java-examples}/DriverLifecycleExample.java[tags=driver-lifecycle-import]
 ----
+
+[source, java]
+----
+include::{java-examples}/DriverLifecycleExample.java[tags=driver-lifecycle]
+----
+
 ======
 
 [.include-with-javascript]
@@ -98,12 +99,14 @@ include::{javascript-examples}/examples.test.js[tags=driver-lifecycle]
 ======
 [source, python]
 ----
-include::{python-examples}/test_driver_lifecycle_example.py[tags=driver-lifecycle]
-----
-[source, python]
-----
 include::{python-examples}/test_driver_lifecycle_example.py[tags=driver-lifecycle-import]
 ----
+
+[source, python]
+----
+include::{python-examples}/test_driver_lifecycle_example.py[tags=driver-lifecycle]
+----
+
 ======
 ====
 
@@ -226,12 +229,14 @@ include::{javascript-examples}/examples.test.js[tags=config-custom-resolver]
 ======
 [source, python]
 ----
-include::{python-examples}/test_custom_resolver_example.py[tags=custom-resolver]
-----
-[source, python]
-----
 include::{python-examples}/test_custom_resolver_example.py[tags=custom-resolver-import]
 ----
+
+[source, python]
+----
+include::{python-examples}/test_custom_resolver_example.py[tags=custom-resolver]
+----
+
 ======
 
 ====
@@ -904,15 +909,15 @@ include::{dotnet-examples}/Examples.cs[tags=basic-auth]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/BasicAuthExample.java[tags=basic-auth]
-----
-
 .Import basic authentication
 [source, java]
 ----
 include::{java-examples}/BasicAuthExample.java[tags=basic-auth-import]
+----
+
+[source, java]
+----
+include::{java-examples}/BasicAuthExample.java[tags=basic-auth]
 ----
 ======
 
@@ -934,11 +939,12 @@ include::{javascript-examples}/examples.test.js[tags=basic-auth]
 ======
 [source, python]
 ----
-include::{python-examples}/test_basic_auth_example.py[tags=basic-auth]
+include::{python-examples}/test_basic_auth_example.py[tags=basic-auth-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_basic_auth_example.py[tags=basic-auth-import]
+include::{python-examples}/test_basic_auth_example.py[tags=basic-auth]
 ----
 ======
 
@@ -975,15 +981,15 @@ include::{dotnet-examples}/Examples.cs[tags=kerberos-auth]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/KerberosAuthExample.java[tags=kerberos-auth]
-----
-
 .Import Kerberos authentication
 [source, java]
 ----
 include::{java-examples}/KerberosAuthExample.java[tags=kerberos-auth-import]
+----
+
+[source, java]
+----
+include::{java-examples}/KerberosAuthExample.java[tags=kerberos-auth]
 ----
 ======
 
@@ -1005,11 +1011,12 @@ include::{javascript-examples}/examples.test.js[tags=kerberos-auth]
 ======
 [source, python]
 ----
-include::{python-examples}/test_kerberos_auth_example.py[tags=kerberos-auth]
+include::{python-examples}/test_kerberos_auth_example.py[tags=kerberos-auth-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_kerberos_auth_example.py[tags=kerberos-auth-import]
+include::{python-examples}/test_kerberos_auth_example.py[tags=kerberos-auth]
 ----
 ======
 
@@ -1045,15 +1052,15 @@ include::{dotnet-examples}/Examples.cs[tags=custom-auth]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/CustomAuthExample.java[tags=custom-auth]
-----
-
 .Import custom authentication
 [source, java]
 ----
 include::{java-examples}/CustomAuthExample.java[tags=custom-auth-import]
+----
+
+[source, java]
+----
+include::{java-examples}/CustomAuthExample.java[tags=custom-auth]
 ----
 ======
 
@@ -1074,11 +1081,12 @@ include::{javascript-examples}/examples.test.js[tags=custom-auth]
 ======
 [source, python]
 ----
-include::{python-examples}/test_custom_auth_example.py[tags=custom-auth]
+include::{python-examples}/test_custom_auth_example.py[tags=custom-auth-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_custom_auth_example.py[tags=custom-auth-import]
+include::{python-examples}/test_custom_auth_example.py[tags=custom-auth]
 ----
 ======
 
@@ -1119,15 +1127,15 @@ include::{dotnet-examples}/Examples.cs[tags=config-connection-pool]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/ConfigConnectionPoolExample.java[tags=config-connection-pool]
-----
-
 .Import connection pool configuration
 [source, java]
 ----
 include::{java-examples}/ConfigConnectionPoolExample.java[tags=config-connection-pool-import]
+----
+
+[source, java]
+----
+include::{java-examples}/ConfigConnectionPoolExample.java[tags=config-connection-pool]
 ----
 ======
 
@@ -1149,11 +1157,12 @@ include::{javascript-examples}/examples.test.js[tags=config-connection-pool]
 ======
 [source, python]
 ----
-include::{python-examples}/test_config_connection_pool_example.py[tags=config-connection-pool]
+include::{python-examples}/test_config_connection_pool_example.py[tags=config-connection-pool-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_config_connection_pool_example.py[tags=config-connection-pool-import]
+include::{python-examples}/test_config_connection_pool_example.py[tags=config-connection-pool]
 ----
 ======
 
@@ -1192,14 +1201,15 @@ include::{dotnet-examples}/Examples.cs[tags=config-connection-timeout]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/ConfigConnectionTimeoutExample.java[tags=config-connection-timeout]
-----
 .Import connection timeout configuration
 [source, java]
 ----
 include::{java-examples}/ConfigConnectionTimeoutExample.java[tags=config-connection-timeout-import]
+----
+
+[source, java]
+----
+include::{java-examples}/ConfigConnectionTimeoutExample.java[tags=config-connection-timeout]
 ----
 ======
 
@@ -1220,11 +1230,12 @@ include::{javascript-examples}/examples.test.js[tags=config-connection-timeout]
 ======
 [source, python]
 ----
-include::{python-examples}/test_config_connection_timeout_example.py[tags=config-connection-timeout]
+include::{python-examples}/test_config_connection_timeout_example.py[tags=config-connection-timeout-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_config_connection_timeout_example.py[tags=config-connection-timeout-import]
+include::{python-examples}/test_config_connection_timeout_example.py[tags=config-connection-timeout]
 ----
 ======
 
@@ -1259,14 +1270,15 @@ include::{dotnet-examples}/Examples.cs[tags=config-unencrypted]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/ConfigUnencryptedExample.java[tags=config-unencrypted]
-----
 .Import unencrypted configuration
 [source, java]
 ----
 include::{java-examples}/ConfigUnencryptedExample.java[tags=config-unencrypted-import]
+----
+
+[source, java]
+----
+include::{java-examples}/ConfigUnencryptedExample.java[tags=config-unencrypted]
 ----
 ======
 
@@ -1287,11 +1299,12 @@ include::{javascript-examples}/examples.test.js[tags=config-unencrypted]
 ======
 [source, python]
 ----
-include::{python-examples}/test_config_unencrypted_example.py[tags=config-unencrypted]
+include::{python-examples}/test_config_unencrypted_example.py[tags=config-unencrypted-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_config_unencrypted_example.py[tags=config-unencrypted-import]
+include::{python-examples}/test_config_unencrypted_example.py[tags=config-unencrypted]
 ----
 ======
 
@@ -1356,14 +1369,15 @@ include::{dotnet-examples}/Examples.cs[tags=config-max-retry-time]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/ConfigMaxRetryTimeExample.java[tags=config-max-retry-time]
-----
 .Import maximum retry time configuration
 [source, java]
 ----
 include::{java-examples}/ConfigMaxRetryTimeExample.java[tags=config-max-retry-time-import]
+----
+
+[source, java]
+----
+include::{java-examples}/ConfigMaxRetryTimeExample.java[tags=config-max-retry-time]
 ----
 ======
 
@@ -1384,11 +1398,12 @@ include::{javascript-examples}/examples.test.js[tags=config-max-retry-time]
 ======
 [source, python]
 ----
-include::{python-examples}/test_config_max_retry_time_example.py[tags=config-max-retry-time]
+include::{python-examples}/test_config_max_retry_time_example.py[tags=config-max-retry-time-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_config_max_retry_time_example.py[tags=config-max-retry-time-import]
+include::{python-examples}/test_config_max_retry_time_example.py[tags=config-max-retry-time]
 ----
 ======
 
@@ -1427,14 +1442,15 @@ include::{dotnet-examples}/Examples.cs[tags=config-trust]
 
 [.include-with-java]
 ======
-[source, java]
-----
-include::{java-examples}/ConfigTrustExample.java[tags=config-trust]
-----
 .Import trusted certificate configuration
 [source, java]
 ----
 include::{java-examples}/ConfigTrustExample.java[tags=config-trust-import]
+----
+
+[source, java]
+----
+include::{java-examples}/ConfigTrustExample.java[tags=config-trust]
 ----
 ======
 
@@ -1455,11 +1471,12 @@ include::{javascript-examples}/examples.test.js[tags=config-trust]
 ======
 [source, python]
 ----
-include::{python-examples}/test_config_trust_example.py[tags=config-trust]
+include::{python-examples}/test_config_trust_example.py[tags=config-trust-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_config_trust_example.py[tags=config-trust-import]
+include::{python-examples}/test_config_trust_example.py[tags=config-trust]
 ----
 ======
 

--- a/asciidoc/cypher-workflow.adoc
+++ b/asciidoc/cypher-workflow.adoc
@@ -68,6 +68,7 @@ A lower-level *_unmanaged transaction API_* is also available for advanced use c
 This is useful when an alternative transaction management layer is applied by the client, in which error handling and retries need to be managed in a custom way.
 To learn more about how to use unmanaged transactions, see <<driver-api-docs, API documentation>> for the relevant language.
 
+
 [[driver-queries-results]]
 == Queries and results
 
@@ -133,16 +134,16 @@ include::{dotnet-examples}/Examples.cs[tags=pass-bookmarks]
 
 [.include-with-java]
 ======
-.Pass bookmarks
-[source, java]
-----
-include::{java-examples}/PassBookmarkExample.java[tags=pass-bookmarks]
-----
-
 .Import bookmarks
 [source, java]
 ----
 include::{java-examples}/PassBookmarkExample.java[tags=pass-bookmarks-import]
+----
+
+.Pass bookmarks
+[source, java]
+----
+include::{java-examples}/PassBookmarkExample.java[tags=pass-bookmarks]
 ----
 ======
 
@@ -166,11 +167,12 @@ include::{javascript-examples}/examples.test.js[tags=pass-bookmarks]
 ======
 [source, python]
 ----
-include::{python-examples}/test_pass_bookmarks_example.py[tags=pass-bookmarks]
+include::{python-examples}/test_pass_bookmarks_example.py[tags=pass-bookmarks-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_pass_bookmarks_example.py[tags=pass-bookmarks-import]
+include::{python-examples}/test_pass_bookmarks_example.py[tags=pass-bookmarks]
 ----
 ======
 
@@ -228,17 +230,16 @@ include::{dotnet-examples}/Examples.cs[tags=read-write-transaction]
 
 [.include-with-java]
 ======
+.Import read write transaction
+[source, java]
+----
+include::{java-examples}/ReadWriteTransactionExample.java[tags=read-write-transaction-import]
+----
 
 .Read write transaction
 [source, java]
 ----
 include::{java-examples}/ReadWriteTransactionExample.java[tags=read-write-transaction]
-----
-
-.Import read write transaction
-[source, java]
-----
-include::{java-examples}/ReadWriteTransactionExample.java[tags=read-write-transaction-import]
 ----
 ======
 
@@ -322,16 +323,16 @@ include::{dotnet-examples}/Examples.cs[tags=database-selection]
 
 [.include-with-java]
 ======
-.Database selection on session creation
-[source, java]
-----
-include::{java-examples}/DatabaseSelectionExample.java[tags=database-selection]
-----
-
 .Import database selection on session creation
 [source, java]
 ----
 include::{java-examples}/DatabaseSelectionExample.java[tags=database-selection-import]
+----
+
+.Database selection on session creation
+[source, java]
+----
+include::{java-examples}/DatabaseSelectionExample.java[tags=database-selection]
 ----
 ======
 
@@ -347,13 +348,14 @@ include::{javascript-examples}/examples.test.js[tags=database-selection]
 [.include-with-python]
 ======
 [source, python]
-.Database selection on session creation
-----
-include::{python-examples}/test_database_selection_example.py[tags=database-selection]
-----
-[source, python]
 ----
 include::{python-examples}/test_database_selection_example.py[tags=database-selection-import]
+----
+
+.Database selection on session creation
+[source, python]
+----
+include::{python-examples}/test_database_selection_example.py[tags=database-selection]
 ----
 ======
 

--- a/asciidoc/get-started.adoc
+++ b/asciidoc/get-started.adoc
@@ -383,13 +383,14 @@ include::{dotnet-examples}/Examples.cs[tags=hello-world]
 ======
 [source, java]
 ----
-include::{java-examples}/HelloWorldExample.java[tags=hello-world]
+include::{java-examples}/HelloWorldExample.java[tags=hello-world-import]
 ----
 
 [source, java]
 ----
-include::{java-examples}/HelloWorldExample.java[tags=hello-world-import]
+include::{java-examples}/HelloWorldExample.java[tags=hello-world]
 ----
+
 ======
 
 [.include-with-javascript]
@@ -409,12 +410,14 @@ include::{javascript-examples}/examples.test.js[tags=hello-world]
 ======
 [source, python]
 ----
-include::{python-examples}/test_hello_world_example.py[tags=hello-world]
-----
-[source, python]
-----
 include::{python-examples}/test_hello_world_example.py[tags=hello-world-import]
 ----
+
+[source, python]
+----
+include::{python-examples}/test_hello_world_example.py[tags=hello-world]
+----
+
 ======
 
 ====

--- a/asciidoc/session-api.adoc
+++ b/asciidoc/session-api.adoc
@@ -93,6 +93,7 @@ with driver.session(...) as session:
 This is carried out by supplying configuration inside the session constructor.
 See <<Session configuration>> for more details.
 
+
 [[driver-simple-transaction-fn]]
 === Transaction functions
 
@@ -143,11 +144,12 @@ include::{java-examples}/TransactionFunctionExample.java[tags=transaction-functi
 ======
 [source, python]
 ----
-include::{python-examples}/test_transaction_function_example.py[tags=transaction-function]
+include::{python-examples}/test_transaction_function_example.py[tags=transaction-function-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_transaction_function_example.py[tags=transaction-function-import]
+include::{python-examples}/test_transaction_function_example.py[tags=transaction-function]
 ----
 ======
 
@@ -200,11 +202,12 @@ include::{java-examples}/AutocommitTransactionExample.java[tags=autocommit-trans
 ======
 [source, python]
 ----
-include::{python-examples}/test_autocommit_transaction_example.py[tags=autocommit-transaction]
+include::{python-examples}/test_autocommit_transaction_example.py[tags=autocommit-transaction-import]
 ----
+
 [source, python]
 ----
-include::{python-examples}/test_autocommit_transaction_example.py[tags=autocommit-transaction-import]
+include::{python-examples}/test_autocommit_transaction_example.py[tags=autocommit-transaction]
 ----
 ======
 
@@ -319,6 +322,7 @@ Available in:
 Asynchronous sessions provide an API wherein function calls typically return available objects such as futures.
 This allows client applications to work within asynchronous frameworks and take advantage of cooperative multitasking.
 
+
 [[driver-async-lifecycle]]
 === Lifecycle
 
@@ -327,6 +331,7 @@ A session then exists until it is closed, which is typically set to occur after 
 
 Sessions can be configured in a number of different ways. This is carried out by supplying configuration inside the session constructor.
 See <<Session configuration>> for more details.
+
 
 [[driver-async-transaction-fn]]
 === Transaction functions
@@ -386,6 +391,7 @@ include::{javascript-examples}/examples.test.js[tags=async-transaction-function]
 ======
 ========
 
+
 [[driver-async-autocommit-transactions]]
 === Auto-commit transactions
 
@@ -444,6 +450,7 @@ include::{javascript-examples}/examples.test.js[tags=async-autocommit-transactio
 ======
 ========
 
+
 [[driver-async-result-consume]]
 === Consuming results
 
@@ -483,6 +490,7 @@ include::{javascript-examples}/examples.test.js[tags=async-result-consume]
 ----
 ======
 ========
+
 
 [[driver-rx-sessions]]
 == Reactive Sessions
@@ -524,11 +532,13 @@ Reactive sessions will typically be used in a client application that is already
 Refer to <<driver-get-started>> for more information on recommended dependencies.
 --
 
+
 [[driver-rx-lifecycle]]
 === Lifecycle
 
 Session lifetime begins with session construction.
 A session then exists until it is closed, which is typically set to occur after its contained query results have been consumed.
+
 
 [[driver-rx-transaction-fn]]
 === Transaction functions
@@ -590,6 +600,7 @@ Sessions can be configured in a number of different ways.
 This is carried out by supplying configuration inside the session constructor.
 See <<driver-session-configuration>> for more details.
 
+
 [[driver-rx-autocommit-transactions]]
 === Auto-commit transactions
 
@@ -648,6 +659,7 @@ include::{javascript-examples}/examples.test.js[tags=rx-autocommit-transaction]
 ======
 ========
 
+
 [[driver-rx-result-consume]]
 === Consuming results
 
@@ -691,6 +703,7 @@ include::{javascript-examples}/examples.test.js[tags=rx-result-consume]
 ----
 ======
 ========
+
 
 [[driver-rx-cancellation]]
 === Cancellation


### PR DESCRIPTION
Examples in both Java and Python driver docs had the import statement after the results - this PR switches them.