### PR TITLE
4.2 fix warnings from antora build

### DIFF
--- a/commonManual/asciidoc/cypher-workflow.adoc
+++ b/commonManual/asciidoc/cypher-workflow.adoc
@@ -323,7 +323,7 @@ The database name must not be `null`, nor an empty string.
 *_The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition_*.
 Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-The following example illustrates the concept of DBMS <<cypher-manual#transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
+The following example illustrates the concept of DBMS <<cypher-manual#dbms-transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
 
 [source]
 ----

--- a/commonManual/asciidoc/session-api.adoc
+++ b/commonManual/asciidoc/session-api.adoc
@@ -92,7 +92,7 @@ with driver.session(...) as session:
 
 *_Sessions can be configured in a number of different ways_*.
 This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-simple-transaction-fn]]
@@ -334,7 +334,7 @@ Session lifetime begins with session construction.
 A session then exists until it is closed, which is typically set to occur after its contained query results have been consumed.
 
 Sessions can be configured in a number of different ways. This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 [[driver-async-transaction-fn]]
 === Transaction functions
@@ -739,6 +739,6 @@ See <<operations-manual#manage-databases-default, Operations Manual -> The defau
 `Fetch Size`::
 The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
-This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-asynchronous-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
+This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records

--- a/dotnetManual/asciidoc/cypher-workflow.adoc
+++ b/dotnetManual/asciidoc/cypher-workflow.adoc
@@ -212,7 +212,7 @@ The database name must not be `null`, nor an empty string.
 *_The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition_*.
 Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-The following example illustrates the concept of DBMS <<cypher-manual#transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
+The following example illustrates the concept of DBMS <<cypher-manual#dbms-transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
 
 [source]
 ----

--- a/dotnetManual/asciidoc/session-api.adoc
+++ b/dotnetManual/asciidoc/session-api.adoc
@@ -6,7 +6,6 @@
 This section details the Session API that are made available by the driver, with each Session class oriented towards a different form of programming.
 --
 
-
 [[driver-simple-sessions]]
 == Simple sessions
 
@@ -35,7 +34,7 @@ using (var session = driver.Session(...)) {
 
 *_Sessions can be configured in a number of different ways_*.
 This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-simple-transaction-fn]]
@@ -164,7 +163,7 @@ Session lifetime begins with session construction.
 A session then exists until it is closed, which is typically set to occur after its contained query results have been consumed.
 
 Sessions can be configured in a number of different ways. This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-async-transaction-fn]]
@@ -400,6 +399,6 @@ See <<operations-manual#manage-databases-default, Operations Manual -> The defau
 `Fetch Size`::
 The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
-This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-asynchronous-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
+This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records

--- a/dotnetManual/asciidoc/terminology.adoc
+++ b/dotnetManual/asciidoc/terminology.adoc
@@ -29,7 +29,8 @@ A Neo4j instance that can accept incoming Bolt connections.
 [[term-bookmark]]bookmark::
 A marker for a point in the transactional history of Neo4j.
 
-[[term-causal-chaining]]causal chaining::
+[[term-causal-chaining]]
+causal chaining::
 A mechanism to ensure that the transactions carried out in a session are executed in order, even when each transaction may be carried out on different cluster members.
 
 [[term-client-application]]client application::
@@ -66,7 +67,8 @@ A combination of host name and port or IP address and port that targets a server
 [[term-session]]session::
 A causally linked sequence of transactions.
 
-[[term-thread-safety]]thread safety::
+[[term-thread-safety]]
+thread safety::
 See https://en.wikipedia.org/wiki/Thread_safety.
 
 [[term-transaction]]transaction::
@@ -77,5 +79,6 @@ A transaction, by definition, must be atomic, consistent, isolated, and durable.
 [[term-transaction-function]]transaction function::
 The method of grouping a number of queries together which, when run in a session, are retried on failure.
 
-[[term-transaction-manager]]transaction manager::
+[[term-transaction-manager]]
+transaction manager::
 The component/code responsible for deciding what to do if a transaction fails, i.e to retry, give up or do something else.

--- a/dotnetManual/asciidoc/terminology.adoc
+++ b/dotnetManual/asciidoc/terminology.adoc
@@ -29,8 +29,7 @@ A Neo4j instance that can accept incoming Bolt connections.
 [[term-bookmark]]bookmark::
 A marker for a point in the transactional history of Neo4j.
 
-[[term-causal-chaining]]
-causal chaining::
+[[term-causal-chaining]]causal chaining::
 A mechanism to ensure that the transactions carried out in a session are executed in order, even when each transaction may be carried out on different cluster members.
 
 [[term-client-application]]client application::
@@ -67,8 +66,7 @@ A combination of host name and port or IP address and port that targets a server
 [[term-session]]session::
 A causally linked sequence of transactions.
 
-[[term-thread-safety]]
-thread safety::
+[[term-thread-safety]]thread safety::
 See https://en.wikipedia.org/wiki/Thread_safety.
 
 [[term-transaction]]transaction::
@@ -79,6 +77,5 @@ A transaction, by definition, must be atomic, consistent, isolated, and durable.
 [[term-transaction-function]]transaction function::
 The method of grouping a number of queries together which, when run in a session, are retried on failure.
 
-[[term-transaction-manager]]
-transaction manager::
+[[term-transaction-manager]]transaction manager::
 The component/code responsible for deciding what to do if a transaction fails, i.e to retry, give up or do something else.

--- a/goManual/asciidoc/cypher-workflow.adoc
+++ b/goManual/asciidoc/cypher-workflow.adoc
@@ -323,7 +323,7 @@ The database name must not be `null`, nor an empty string.
 *_The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition_*.
 Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-The following example illustrates the concept of DBMS <<cypher-manual#transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
+The following example illustrates the concept of DBMS <<cypher-manual#dbms-transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
 
 [source]
 ----

--- a/goManual/asciidoc/session-api.adoc
+++ b/goManual/asciidoc/session-api.adoc
@@ -92,7 +92,7 @@ with driver.session(...) as session:
 
 *_Sessions can be configured in a number of different ways_*.
 This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-simple-transaction-fn]]
@@ -334,7 +334,7 @@ Session lifetime begins with session construction.
 A session then exists until it is closed, which is typically set to occur after its contained query results have been consumed.
 
 Sessions can be configured in a number of different ways. This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 [[driver-async-transaction-fn]]
 === Transaction functions
@@ -739,6 +739,6 @@ See <<operations-manual#manage-databases-default, Operations Manual -> The defau
 `Fetch Size`::
 The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
-This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-asynchronous-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
+This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records

--- a/javaManual/asciidoc/cypher-workflow.adoc
+++ b/javaManual/asciidoc/cypher-workflow.adoc
@@ -217,7 +217,7 @@ The database name must not be `null`, nor an empty string.
 *_The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition_*.
 Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-The following example illustrates the concept of DBMS <<cypher-manual#transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
+The following example illustrates the concept of DBMS <<cypher-manual#dbms-transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
 
 [source]
 ----

--- a/javaManual/asciidoc/session-api.adoc
+++ b/javaManual/asciidoc/session-api.adoc
@@ -38,7 +38,7 @@ try (Session session = driver.session(...)) {
 
 *_Sessions can be configured in a number of different ways_*.
 This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-simple-transaction-fn]]
@@ -174,7 +174,7 @@ Session lifetime begins with session construction.
 A session then exists until it is closed, which is typically set to occur after its contained query results have been consumed.
 
 Sessions can be configured in a number of different ways. This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-async-transaction-fn]]
@@ -425,6 +425,6 @@ See <<operations-manual#manage-databases-default, Operations Manual -> The defau
 `Fetch Size`::
 The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
-This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-asynchronous-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
+This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records

--- a/jsManual/antora/content-nav.adoc
+++ b/jsManual/antora/content-nav.adoc
@@ -3,7 +3,6 @@
 * xref:client-applications/index.adoc[]
 * xref:cypher-workflow/index.adoc[]
 * xref:session-api/index.adoc[]
-** xref:session-api/simple/index.adoc[Simple Sessions]
 ** xref:session-api/asynchronous/index.adoc[Asynchronous Sessions]
 ** xref:session-api/reactive/index.adoc[Reactive Sessions]
 ** xref:session-api/configuration/index.adoc[Session Configuration]

--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -219,7 +219,7 @@ The database name must not be `null`, nor an empty string.
 *_The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition_*.
 Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-The following example illustrates the concept of DBMS <<cypher-manual#transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
+The following example illustrates the concept of DBMS <<cypher-manual#dbms-transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
 
 [source]
 ----

--- a/jsManual/asciidoc/session-api.adoc
+++ b/jsManual/asciidoc/session-api.adoc
@@ -28,7 +28,7 @@ Session lifetime begins with session construction.
 A session then exists until it is closed, which is typically set to occur after its contained query results have been consumed.
 
 Sessions can be configured in a number of different ways. This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-async-transaction-fn]]
@@ -264,6 +264,6 @@ See <<operations-manual#manage-databases-default, Operations Manual -> The defau
 `Fetch Size`::
 The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
-This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-asynchronous-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
+This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records

--- a/jsManual/docbook/content-map.xml
+++ b/jsManual/docbook/content-map.xml
@@ -9,8 +9,6 @@
     <d:tocentry linkend="driver-cypher-workflow"><?dbhtml filename="cypher-workflow/index.html"?>
     </d:tocentry>
     <d:tocentry linkend="driver-session-api"><?dbhtml filename="session-api/index.html"?>
-      <d:tocentry linkend="driver-simple-sessions"><?dbhtml filename="session-api/simple/index.html"?>
-      </d:tocentry>
       <d:tocentry linkend="driver-async-sessions"><?dbhtml filename="session-api/asynchronous/index.html"?>
       </d:tocentry>
       <d:tocentry linkend="driver-rx-sessions"><?dbhtml filename="session-api/reactive/index.html"?>

--- a/pythonManual/antora/content-nav.adoc
+++ b/pythonManual/antora/content-nav.adoc
@@ -4,7 +4,5 @@
 * xref:cypher-workflow/index.adoc[]
 * xref:session-api/index.adoc[]
 ** xref:session-api/simple/index.adoc[Simple Sessions]
-** xref:session-api/asynchronous/index.adoc[Asynchronous Sessions]
-** xref:session-api/reactive/index.adoc[Reactive Sessions]
 ** xref:session-api/configuration/index.adoc[Session Configuration]
 * xref:terminology/index.adoc[]

--- a/pythonManual/asciidoc/client-applications.adoc
+++ b/pythonManual/asciidoc/client-applications.adoc
@@ -35,7 +35,6 @@ Therefore, if multiple configurations are required (such as when working with mu
 
 .The driver lifecycle
 [source, python]
-======
 ----
 include::{python-examples}/test_driver_lifecycle_example.py[tags=driver-lifecycle-import]
 ----
@@ -44,7 +43,6 @@ include::{python-examples}/test_driver_lifecycle_example.py[tags=driver-lifecycl
 ----
 include::{python-examples}/test_driver_lifecycle_example.py[tags=driver-lifecycle]
 ----
-======
 
 
 [[driver-connection-uris]]

--- a/pythonManual/asciidoc/cypher-workflow.adoc
+++ b/pythonManual/asciidoc/cypher-workflow.adoc
@@ -210,7 +210,7 @@ The database name must not be `null`, nor an empty string.
 *_The selection of database is only possible when the driver is connected against Neo4j Enterprise Edition_*.
 Changing to any other database than the default database in Neo4j Community Edition will lead to a runtime error.
 
-The following example illustrates the concept of DBMS <<cypher-manual#transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
+The following example illustrates the concept of DBMS <<cypher-manual#dbms-transactions, Cypher Manual -> Transactions>> and shows how queries to multiple databases can be issued in one driver transaction. It is annotated with comments describing how each operation impacts database transactions.
 
 [source]
 ----

--- a/pythonManual/asciidoc/session-api.adoc
+++ b/pythonManual/asciidoc/session-api.adoc
@@ -34,7 +34,7 @@ with driver.session(...) as session:
 
 *_Sessions can be configured in a number of different ways_*.
 This is carried out by supplying configuration inside the session constructor.
-See <<Session configuration>> for more details.
+See <<driver-session-configuration>> for more details.
 
 
 [[driver-simple-transaction-fn]]
@@ -155,3 +155,40 @@ The drivers offer support for this process, as per the example below:
 ----
 include::{python-examples}/test_result_retain_example.py[tags=result-retain]
 ----
+
+[[driver-session-configuration]]
+== Session configuration
+
+[abstract]
+--
+This section details the configuration options available when constructing a session.
+--
+
+[.compact]
+`Bookmarks`::
+The mechanism which ensures causal consistency between transactions within a session.
+Bookmarks are implicitly passed between transactions within a single session to meet the causal consistency requirements.
+There may be scenarios where you might want to use the bookmark from one session in a different new session.
++
+*Default:* None (Sessions will initially be created without a bookmark)
+
+`DefaultAccessMode`::
+A fallback for the access mode setting when transaction functions are not used.
+Typically, access mode is set per transaction by calling the appropriate transaction function method.
+In other cases, this setting is inherited. Note that transaction functions will ignore/override this setting.
++
+*Default:* Write
+
+`Database`::
+The database with which the session will interact.
+When you are working with a database which is not the default (i.e. the `system` database or another database in Neo4j 4.0 Enterprise Edition), you can explicitly configure the database which the driver is executing transactions against.
+See <<operations-manual#manage-databases-default, Operations Manual -> The default database>> for more information on databases.
++
+*Default:* the default database as configured on the server.
+
+`Fetch Size`::
+The number of records to fetch in each batch from the server.
+Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
+This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
++
+*Default:* 1000 records

--- a/pythonManual/docbook/content-map.xml
+++ b/pythonManual/docbook/content-map.xml
@@ -11,10 +11,6 @@
     <d:tocentry linkend="driver-session-api"><?dbhtml filename="session-api/index.html"?>
       <d:tocentry linkend="driver-simple-sessions"><?dbhtml filename="session-api/simple/index.html"?>
       </d:tocentry>
-      <d:tocentry linkend="driver-async-sessions"><?dbhtml filename="session-api/asynchronous/index.html"?>
-      </d:tocentry>
-      <d:tocentry linkend="driver-rx-sessions"><?dbhtml filename="session-api/reactive/index.html"?>
-      </d:tocentry>
       <d:tocentry linkend="driver-session-configuration"><?dbhtml filename="session-api/configuration/index.html"?>
       </d:tocentry>
     </d:tocentry>


### PR DESCRIPTION
Fixes some xrefs and navigation issues

Still a few issues with broken links but these are probably best resolved during the remaining work to complete each individual manual - for example the Session API topics are all actually in one file but these could be split into multiple adoc source files, and there is some editing needed here and there because not all the session considerations apply to all driver languages. 