### PR TITLE
update Java driver sources to 4.1.2

### DIFF
--- a/antora/antora.yml
+++ b/antora/antora.yml
@@ -11,12 +11,12 @@ asciidoc:
     neo4j-buildnumber: '4.1'
     dotnet-examples: 'partial$driver-sources/dotnet-driver/4.1.1/Neo4j.Driver/Neo4j.Driver.Tests.Integration'
     go-examples: 'partial$driver-sources/go-driver/4.0/neo4j/test-integration'
-    java-examples: 'partial$driver-sources/java-driver/4.1.1/examples/src/main/java/org/neo4j/docs/driver'
+    java-examples: 'partial$driver-sources/java-driver/4.1.2/examples/src/main/java/org/neo4j/docs/driver'
     javascript-examples: 'partial$driver-sources/javascript-driver/4.1.2/test'
     python-examples: 'partial$driver-sources/python-driver/4.1.3/tests/integration/examples'
     driver-version: "4.1"
     dotnet-driver-version: "4.1.1"
     go-driver-version: "4.1"
-    java-driver-version: "4.1.1"
+    java-driver-version: "4.1.2"
     javascript-driver-version: "4.1.2"
     python-driver-version: "4.1.3"


### PR DESCRIPTION
Updates antora.yml with 4.1.2 for Java examples.