### PR TITLE
Update the versioning in the 4.3 Drivers documentation

### DIFF
--- a/dotnetManual/antora/antora.yml
+++ b/dotnetManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: dotnet-manual
 title: Neo4j .NET Driver Manual
-version: '4.2'
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.2'
-    neo4j-version-exact: '4.2.3'
-    neo4j-buildnumber: '4.2'
-    driver-version: "4.2"
-    dotnet-driver-version: "4.2.0"
-    dotnet-examples: 'partial$driver-sources/dotnet-driver/4.2.0/Neo4j.Driver/Neo4j.Driver.Tests.Integration'
+    neo4j-version: '4.3'
+    neo4j-version-exact: '4.3.0'
+    neo4j-buildnumber: '4.3'
+    driver-version: "4.3"
+    dotnet-driver-version: "4.3.0"
+    dotnet-examples: 'partial$driver-sources/dotnet-driver/4.3.0/Neo4j.Driver/Neo4j.Driver.Tests.Integration'

--- a/goManual/antora/antora.yml
+++ b/goManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: go-manual
 title: Neo4j Go Driver Manual
-version: '4.2'
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.2'
-    neo4j-version-exact: '4.2.3'
-    neo4j-buildnumber: '4.2'
-    driver-version: "4.2"
-    go-driver-version: "4.2"
-    go-examples: 'partial$driver-sources/go-driver/4.2/neo4j/test-integration'
+    neo4j-version: '4.3'
+    neo4j-version-exact: '4.3.0'
+    neo4j-buildnumber: '4.3'
+    driver-version: "4.3"
+    go-driver-version: "4.3"
+    go-examples: 'partial$driver-sources/go-driver/4.3/neo4j/test-integration'

--- a/javaManual/antora/antora.yml
+++ b/javaManual/antora/antora.yml
@@ -1,12 +1,12 @@
 name: java-manual
 title: Neo4j Java Driver Manual
-version: '4.2'
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.2'
-    driver-version: "4.2"
-    java-driver-version: "4.2.5"
-    java-examples: 'partial$driver-sources/java-driver/4.2.5/examples/src/main/java/org/neo4j/docs/driver'
+    neo4j-version: '4.3'
+    driver-version: "4.3"
+    java-driver-version: "4.3.0"
+    java-examples: 'partial$driver-sources/java-driver/4.3.0/examples/src/main/java/org/neo4j/docs/driver'

--- a/jsManual/antora/antora.yml
+++ b/jsManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: javascript-manual
 title: Neo4j JavaScript Driver Manual
-version: '4.2'
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.2'
-    neo4j-version-exact: '4.2.3'
-    neo4j-buildnumber: '4.2'
-    driver-version: "4.2"
-    javascript-driver-version: "4.2.3"
-    javascript-examples: 'partial$driver-sources/javascript-driver/4.2.3/test'
+    neo4j-version: '4.3'
+    neo4j-version-exact: '4.3.0'
+    neo4j-buildnumber: '4.3'
+    driver-version: "4.3"
+    javascript-driver-version: "4.3.0"
+    javascript-examples: 'partial$driver-sources/javascript-driver/4.3.0/test'

--- a/pythonManual/antora/antora.yml
+++ b/pythonManual/antora/antora.yml
@@ -7,8 +7,8 @@ nav:
 asciidoc:
   attributes:
     neo4j-version: '4.3'
-    neo4j-version-exact: '4.3.0'
+    neo4j-version-exact: '4.3.1'
     neo4j-buildnumber: '4.3'
     driver-version: "4.3"
-    python-driver-version: "4.3.0"
-    python-examples: "partial$driver-sources/python-driver/4.3.0/tests/integration/examples"
+    python-driver-version: "4.3.1"
+    python-examples: "partial$driver-sources/python-driver/4.3.1/tests/integration/examples"

--- a/pythonManual/antora/antora.yml
+++ b/pythonManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: python-manual
 title: Neo4j Python Driver Manual
-version: '4.2'
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.2'
-    neo4j-version-exact: '4.2.3'
-    neo4j-buildnumber: '4.2'
-    driver-version: "4.2"
-    python-driver-version: "4.2.1"
-    python-examples: "partial$driver-sources/python-driver/4.2.1/tests/integration/examples"
+    neo4j-version: '4.3'
+    neo4j-version-exact: '4.3.0'
+    neo4j-buildnumber: '4.3'
+    driver-version: "4.3"
+    python-driver-version: "4.3.0"
+    python-examples: "partial$driver-sources/python-driver/4.3.0/tests/integration/examples"


### PR DESCRIPTION
@AndyHeap-NeoTech 

This PR updates the versions in each of the Drivers manuals, for 4.3. Each manual requires the right version number in order to pull the examples from the right GitHub repo. Please could you ask the team to check if the versioning is right for each 4.3 driver?

Many thanks