### PR TITLE
javascript: Providing documentation and examples for Temporal types

### DIFF
--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -134,7 +134,7 @@ This section lists some basic usage of the temporal types provided by the JavaSc
 
 
 [[js-driver-temporal-types-datetime]]
-==== DateTime
+==== `dateTime`
 
 Represents an instant capturing the date, the time, and the timezone identifier.
 
@@ -145,7 +145,7 @@ include::{javascript-examples}/examples.test.js[tags=temporal-types-datetime]
 
 
 [[js-driver-temporal-types-date]]
-==== Date
+==== `date`
 
 Represents an instant capturing the date, but not the time, nor the timezone.
 
@@ -156,7 +156,7 @@ include::{javascript-examples}/examples.test.js[tags=temporal-types-date]
 
 
 [[js-driver-temporal-types-time]]
-==== Time
+==== `time`
 
 Represents an instant capturing the time of day, and the timezone offset in seconds, but not the date.
 
@@ -167,7 +167,7 @@ include::{javascript-examples}/examples.test.js[tags=temporal-types-time]
 
 
 [[js-driver-temporal-types-localdatetime]]
-==== LocalDateTime
+==== `localDateTime`
 
 Represents an instant capturing the date and the time, but not the timezone.
 
@@ -178,7 +178,7 @@ include::{javascript-examples}/examples.test.js[tags=temporal-types-localdatetim
 
 
 [[js-driver-temporal-types-localtime]]
-==== LocalTime
+==== `localTime`
 
 Represents an instant capturing the time of day, but not the date, nor the timezone.
 
@@ -189,7 +189,7 @@ include::{javascript-examples}/examples.test.js[tags=temporal-types-localtime]
 
 
 [[js-driver-temporal-types-duration]]
-==== Duration
+==== `duration`
 
 Represents an ISO 8601 duration.
 Contains both date-based values (years, months, days) and time-based values (seconds, nanoseconds).

--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -178,7 +178,8 @@ include::{javascript-examples}/examples.test.js[tags=temporal-types-localtime]
 
 [[js-driver-temporal-types-duration]]
 ==== Duration
-Represents an ISO 8601 duration. Contains both date-based values (years, months, days) and time-based values (seconds, nanoseconds).
+Represents an ISO 8601 duration. 
+Contains both date-based values (years, months, days) and time-based values (seconds, nanoseconds).
 
 [source, javascript]
 ----

--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -129,19 +129,24 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 
 [[js-driver-temporal-types]]
 === Temporal Types
-This section list some basic usage of the temporal types provided by the driver.
+
+This section lists some basic usage of the temporal types provided by the JavaScript Driver.
+
 
 [[js-driver-temporal-types-datetime]]
 ==== DateTime
-Represents an instant capturing the date, the time and the timezone identifier.
+
+Represents an instant capturing the date, the time, and the timezone identifier.
 
 [source, javascript]
 ----
 include::{javascript-examples}/examples.test.js[tags=temporal-types-datetime]
 ----
 
+
 [[js-driver-temporal-types-date]]
 ==== Date
+
 Represents an instant capturing the date, but not the time, nor the timezone.
 
 [source, javascript]
@@ -149,8 +154,10 @@ Represents an instant capturing the date, but not the time, nor the timezone.
 include::{javascript-examples}/examples.test.js[tags=temporal-types-date]
 ----
 
+
 [[js-driver-temporal-types-time]]
 ==== Time
+
 Represents an instant capturing the time of day, and the timezone offset in seconds, but not the date.
 
 [source, javascript]
@@ -158,8 +165,10 @@ Represents an instant capturing the time of day, and the timezone offset in seco
 include::{javascript-examples}/examples.test.js[tags=temporal-types-time]
 ----
 
+
 [[js-driver-temporal-types-localdatetime]]
 ==== LocalDateTime
+
 Represents an instant capturing the date and the time, but not the timezone.
 
 [source, javascript]
@@ -167,8 +176,10 @@ Represents an instant capturing the date and the time, but not the timezone.
 include::{javascript-examples}/examples.test.js[tags=temporal-types-localdatetime]
 ----
 
+
 [[js-driver-temporal-types-localtime]]
 ==== LocalTime
+
 Represents an instant capturing the time of day, but not the date, nor the timezone.
 
 [source, javascript]
@@ -176,15 +187,18 @@ Represents an instant capturing the time of day, but not the date, nor the timez
 include::{javascript-examples}/examples.test.js[tags=temporal-types-localtime]
 ----
 
+
 [[js-driver-temporal-types-duration]]
 ==== Duration
-Represents an ISO 8601 duration. 
+
+Represents an ISO 8601 duration.
 Contains both date-based values (years, months, days) and time-based values (seconds, nanoseconds).
 
 [source, javascript]
 ----
 include::{javascript-examples}/examples.test.js[tags=temporal-types-duration]
 ----
+
 
 [[js-driver-exceptions-errors]]
 == Exceptions and error handling

--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -127,6 +127,64 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 ======
 
 
+[[js-driver-temporal-types]]
+=== Temporal Types
+This section list some basic usage of the temporal types provided by the driver.
+
+[[js-driver-temporal-types-datetime]]
+==== DateTime
+Represents an instant capturing the date, the time and the timezone identifier.
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=temporal-types-datetime]
+----
+
+[[js-driver-temporal-types-date]]
+==== Date
+Represents an instant capturing the date, but not the time, nor the timezone.
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=temporal-types-date]
+----
+
+[[js-driver-temporal-types-time]]
+==== Time
+Represents an instant capturing the time of day, and the timezone offset in seconds, but not the date.
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=temporal-types-time]
+----
+
+[[js-driver-temporal-types-localdatetime]]
+==== LocalDateTime
+Represents an instant capturing the date and the time, but not the timezone.
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=temporal-types-localdatetime]
+----
+
+[[js-driver-temporal-types-localtime]]
+==== LocalTime
+Represents an instant capturing the time of day, but not the date, nor the timezone.
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=temporal-types-localtime]
+----
+
+[[js-driver-temporal-types-duration]]
+==== Duration
+Represents an ISO 8601 duration. Contains both date-based values (years, months, days) and time-based values (seconds, nanoseconds).
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=temporal-types-duration]
+----
+
 [[js-driver-exceptions-errors]]
 == Exceptions and error handling
 


### PR DESCRIPTION
Adding section with usage examples of the temporal types.

A sub-section is added to https://neo4j.com/docs/javascript-manual/current/cypher-workflow/#js-driver-type-mapping

See: 
<img width="1792" alt="Screenshot 2021-06-07 at 15 10 36" src="https://user-images.githubusercontent.com/1593958/121022386-9302dd80-c7a2-11eb-9f52-cd5c6e929ace.png">

