### PR TITLE
java-driver: add a section discussing the Value interface

### DIFF
--- a/javaManual/asciidoc/cypher-workflow.adoc
+++ b/javaManual/asciidoc/cypher-workflow.adoc
@@ -141,7 +141,7 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 === Reading Values
 The `Value` interfaces describes methods to inferring and coercing the type of the values returned by Neo4j. The type inference methods start with `is` followed
 by the name of the type and the types coercion methods start with `as`. The coercion methods, except `asObject()` and `asString()`, throws `Uncoercible`
-exception if the value is null. In manner to avoid this kind exceptions, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used depending on the
+exception if the value is null. To avoid this kind exception, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used depending on the
 need.
 
 [source, java]

--- a/javaManual/asciidoc/cypher-workflow.adoc
+++ b/javaManual/asciidoc/cypher-workflow.adoc
@@ -137,6 +137,24 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 +*+ A `Duration` or `Period` passed as a parameter will always be implicitly converted to `IsoDuration`.
 ======
 
+[[java-driver-reading-values]]
+=== Reading Values
+The `Value` interfaces describes methods to inferring and coercing the type of the values returned by Neo4j. The type inference methods start with `is` followed
+by the name of the type and the types coercion methods start with `as`. The coercion methods, except `asObject()` and `asString()`, throws `Uncoercible`
+exception if the value is null. In manner to avoid this kind exceptions, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used depending on the
+need.
+
+[source, java]
+----
+include::{java-examples}/ReadingValuesExample.java[tags=java-driver-reading-values-non-null]
+----
+
+[source, java]
+----
+include::{java-examples}/ReadingValuesExample.java[tags=java-driver-reading-values-null]
+----
+
+See https://neo4j.com/docs/api/java-driver/4.2/org/neo4j/driver/Value.html for further details.
 
 [[java-driver-exceptions-errors]]
 == Exceptions and error handling

--- a/javaManual/asciidoc/cypher-workflow.adoc
+++ b/javaManual/asciidoc/cypher-workflow.adoc
@@ -140,7 +140,7 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 [[java-driver-reading-values]]
 === Reading Values
 The `Value` interfaces describes methods to inferring and coercing the type of the values returned by Neo4j. The type inference methods start with `is` followed
-by the name of the type and the types coercion methods start with `as`. The coercion methods, except `asObject()` and `asString()`, throws `Uncoercible`
+by the name of the type and the type coercion methods start with `as`. The coercion methods, except `asObject()` and `asString()`, throw a `Uncoercible`
 exception if the value is null. To avoid this kind exception, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used depending on the
 need.
 

--- a/javaManual/asciidoc/cypher-workflow.adoc
+++ b/javaManual/asciidoc/cypher-workflow.adoc
@@ -137,11 +137,16 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 +*+ A `Duration` or `Period` passed as a parameter will always be implicitly converted to `IsoDuration`.
 ======
 
+
 [[java-driver-reading-values]]
 === Reading Values
-The `Value` interface describes methods to infer and coerce the type of values returned by Neo4j. The type inference methods start with `is` followed
-by the name of the type and the type coercion methods start with `as`. The coercion methods, except `asObject()` and `asString()`, throw a `Uncoercible`
-exception if the value is null. To avoid this kind exception, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used depending on the
+
+The `Value` interface describes methods to infer and coerce the type of values returned by Neo4j.
+The type inference methods start with `is`, followed by the name of the type.
+The type coercion methods start with `as`.
+
+The coercion methods, except `asObject()` and `asString()`, throw a `Uncoercible` exception if the value is null.
+To avoid this kind exception, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used, depending on the
 need.
 
 [source, java]
@@ -154,7 +159,8 @@ include::{java-examples}/ReadingValuesExample.java[tags=java-driver-reading-valu
 include::{java-examples}/ReadingValuesExample.java[tags=java-driver-reading-values-null]
 ----
 
-See https://neo4j.com/docs/api/java-driver/4.2/org/neo4j/driver/Value.html for further details.
+For more information, see https://neo4j.com/docs/api/java-driver/{neo4j-version}/org/neo4j/driver/Value.html[Java Driver API documentation -> Interface Value].
+
 
 [[java-driver-exceptions-errors]]
 == Exceptions and error handling

--- a/javaManual/asciidoc/cypher-workflow.adoc
+++ b/javaManual/asciidoc/cypher-workflow.adoc
@@ -139,7 +139,7 @@ include::{common-content}/cypher-workflow.adoc[tag=type-mapping]
 
 [[java-driver-reading-values]]
 === Reading Values
-The `Value` interfaces describes methods to inferring and coercing the type of the values returned by Neo4j. The type inference methods start with `is` followed
+The `Value` interface describes methods to infer and coerce the type of values returned by Neo4j. The type inference methods start with `is` followed
 by the name of the type and the type coercion methods start with `as`. The coercion methods, except `asObject()` and `asString()`, throw a `Uncoercible`
 exception if the value is null. To avoid this kind exception, the `isNull()` or `asTypeName(TypeName defaultValue)` can be used depending on the
 need.


### PR DESCRIPTION
The goal of this section is add brief introduction to the `is` and `as` methods and re-direct the user to the javadocs for further details. 

<img width="1792" alt="Screenshot 2021-06-09 at 11 05 56" src="https://user-images.githubusercontent.com/1593958/121326563-f7dd4580-c912-11eb-8b38-147fa79afb93.png">
