### PR TITLE
Update for 4.3 publish

### DIFF
--- a/dotnetManual/antora/antora.yml
+++ b/dotnetManual/antora/antora.yml
@@ -1,7 +1,6 @@
 name: dotnet-manual
 title: Neo4j .NET Driver Manual
-version: '4.3-preview'
-prerelease: true
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
@@ -11,5 +10,5 @@ asciidoc:
     neo4j-version-exact: '4.3.0'
     neo4j-buildnumber: '4.3'
     driver-version: "4.3"
-    dotnet-driver-version: "4.3.0"
-    dotnet-examples: 'partial$driver-sources/dotnet-driver/4.3.0/Neo4j.Driver/Neo4j.Driver.Tests.Integration'
+    dotnet-driver-version: "4.3.1"
+    dotnet-examples: 'partial$driver-sources/dotnet-driver/4.3.1/Neo4j.Driver/Neo4j.Driver.Tests.Integration'

--- a/goManual/antora/antora.yml
+++ b/goManual/antora/antora.yml
@@ -1,7 +1,6 @@
 name: go-manual
 title: Neo4j Go Driver Manual
-version: '4.3-preview'
-prerelease: true
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/javaManual/antora/antora.yml
+++ b/javaManual/antora/antora.yml
@@ -1,7 +1,6 @@
 name: java-manual
 title: Neo4j Java Driver Manual
-version: '4.3-preview'
-prerelease: true
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/jsManual/antora/antora.yml
+++ b/jsManual/antora/antora.yml
@@ -1,7 +1,6 @@
 name: javascript-manual
 title: Neo4j JavaScript Driver Manual
-version: '4.3-preview'
-prerelease: true
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
@@ -11,5 +10,5 @@ asciidoc:
     neo4j-version-exact: '4.3.0'
     neo4j-buildnumber: '4.3'
     driver-version: "4.3"
-    javascript-driver-version: "4.3.0"
-    javascript-examples: 'partial$driver-sources/javascript-driver/4.3.0/test'
+    javascript-driver-version: "4.3.1"
+    javascript-examples: 'partial$driver-sources/javascript-driver/4.3.1/test'

--- a/pythonManual/antora/antora.yml
+++ b/pythonManual/antora/antora.yml
@@ -1,7 +1,6 @@
 name: python-manual
 title: Neo4j Python Driver Manual
-version: '4.3-preview'
-prerelease: true
+version: '4.3'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
update antora.yml files to remove prerelease and change version to 4.3

Also updates .NET and javaScript manuals to 4.3.1