### PR TITLE
Update antora.yml files for 4.4

### DIFF
--- a/dotnetManual/antora/antora.yml
+++ b/dotnetManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: dotnet-manual
 title: Neo4j .NET Driver Manual
-version: '4.3'
+version: '4.4'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.3'
-    neo4j-version-exact: '4.3.0'
-    neo4j-buildnumber: '4.3'
-    driver-version: "4.3"
-    dotnet-driver-version: "4.3.1"
+    neo4j-version: '4.4'
+    neo4j-version-exact: '4.4.0'
+    neo4j-buildnumber: '4.4'
+    driver-version: "4.4"
+    dotnet-driver-version: "4.4.0"
     dotnet-examples: 'partial$driver-sources/dotnet-driver/Neo4j.Driver/Neo4j.Driver.Tests.Integration'

--- a/dotnetManual/antora/antora.yml
+++ b/dotnetManual/antora/antora.yml
@@ -1,6 +1,7 @@
 name: dotnet-manual
 title: Neo4j .NET Driver Manual
-version: '4.4'
+version: 4.4
+prerelease: -preview
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/goManual/antora/antora.yml
+++ b/goManual/antora/antora.yml
@@ -1,6 +1,7 @@
 name: go-manual
 title: Neo4j Go Driver Manual
-version: '4.4'
+version: 4.4
+prerelease: -preview
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/goManual/antora/antora.yml
+++ b/goManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: go-manual
 title: Neo4j Go Driver Manual
-version: '4.3'
+version: '4.4'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.3'
-    neo4j-version-exact: '4.3.0'
-    neo4j-buildnumber: '4.3'
-    driver-version: "4.3"
-    go-driver-version: "4.3"
+    neo4j-version: '4.4'
+    neo4j-version-exact: '4.4.0'
+    neo4j-buildnumber: '4.4'
+    driver-version: "4.4"
+    go-driver-version: "4.4"
     go-examples: 'partial$driver-sources/go-driver/neo4j/test-integration'

--- a/javaManual/antora/antora.yml
+++ b/javaManual/antora/antora.yml
@@ -1,12 +1,12 @@
 name: java-manual
 title: Neo4j Java Driver Manual
-version: '4.3'
+version: '4.4'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.3'
-    driver-version: "4.3"
-    java-driver-version: "4.3.3"
+    neo4j-version: '4.4'
+    driver-version: "4.4"
+    java-driver-version: "4.4.0"
     java-examples: 'partial$driver-sources/java-driver/examples/src/main/java/org/neo4j/docs/driver'

--- a/javaManual/antora/antora.yml
+++ b/javaManual/antora/antora.yml
@@ -1,6 +1,7 @@
 name: java-manual
 title: Neo4j Java Driver Manual
-version: '4.4'
+version: 4.4
+prerelease: -preview
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/jsManual/antora/antora.yml
+++ b/jsManual/antora/antora.yml
@@ -1,14 +1,14 @@
 name: javascript-manual
 title: Neo4j JavaScript Driver Manual
-version: '4.3'
+version: '4.4'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.3'
-    neo4j-version-exact: '4.3.0'
-    neo4j-buildnumber: '4.3'
-    driver-version: "4.3"
-    javascript-driver-version: "4.3.2"
+    neo4j-version: '4.4'
+    neo4j-version-exact: '4.4.0'
+    neo4j-buildnumber: '4.4'
+    driver-version: "4.4"
+    javascript-driver-version: "4.4.0"
     javascript-examples: 'partial$driver-sources/javascript-driver/test'

--- a/jsManual/antora/antora.yml
+++ b/jsManual/antora/antora.yml
@@ -1,6 +1,7 @@
 name: javascript-manual
 title: Neo4j JavaScript Driver Manual
-version: '4.4'
+version: 4.4
+prerelease: -preview
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/pythonManual/antora/antora.yml
+++ b/pythonManual/antora/antora.yml
@@ -1,6 +1,7 @@
 name: python-manual
 title: Neo4j Python Driver Manual
-version: '4.4'
+version: 4.4
+prerelease: -preview
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/pythonManual/antora/antora.yml
+++ b/pythonManual/antora/antora.yml
@@ -1,13 +1,13 @@
 name: python-manual
 title: Neo4j Python Driver Manual
-version: '4.3'
+version: '4.4'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
-    neo4j-version: '4.3'
-    neo4j-buildnumber: '4.3'
-    driver-version: "4.3"
-    python-driver-version: "4.3.3"
+    neo4j-version: '4.4'
+    neo4j-buildnumber: '4.4'
+    driver-version: "4.4"
+    python-driver-version: "4.4.0"
     python-examples: "partial$driver-sources/python-driver/tests/integration/examples"


### PR DESCRIPTION
Rather than use 4.4-preview in the url, we can use 4.4 but mark as prerelease using `prerelease: -preview`.

Antora will treat the version as prerelease, so it is not included in version pickers, the urls will be _../4.4/_, but anywhere that Antora displays the version number, it is displayed as '4.4-preview'.