### PR TITLE
Python: improve logging example

### DIFF
--- a/pythonManual/asciidoc/client-applications.adoc
+++ b/pythonManual/asciidoc/client-applications.adoc
@@ -491,8 +491,11 @@ include::{common-content}/client-applications.adoc[tag=logging]
 
 [source, python]
 ----
-from logging import getLogger, StreamHandler, DEBUG
-handler = StreamHandler()
-handler.setLevel(DEBUG)
-getLogger("neo4j").addHandler(handler)
+import logging
+import sys
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+logging.getLogger("neo4j").addHandler(handler)
+logging.getLogger("neo4j").setLevel(logging.DEBUG)
 ----


### PR DESCRIPTION
It's arguably cleaner code style, but more importantly, I explicitly set the log level of the "neo4j" logger. Only messages that are above the handler's *and* the logger's configured log level will be logged.