### PR TITLE
Js: Update driver manual examples path

### DIFF
--- a/commonManual/asciidoc/index.adoc
+++ b/commonManual/asciidoc/index.adoc
@@ -20,7 +20,7 @@ ifndef::python-root[:python-root: {project-root}/build/driver-sources/python-dri
 :dotnet-examples: {dotnet-root}/Neo4j.Driver/Neo4j.Driver.Tests.Integration
 :go-examples: {go-root}/neo4j/test-integration
 :java-examples: {java-root}/examples/src/main/java/org/neo4j/docs/driver
-:javascript-examples: {javascript-root}/test
+:javascript-examples: {javascript-root}/packages/neo4j-driver/test
 :python-examples: {python-root}/tests/integration/examples
 :api-docs-base-uri: https://neo4j.com/docs/api
 

--- a/jsManual/antora/antora.yml
+++ b/jsManual/antora/antora.yml
@@ -12,4 +12,4 @@ asciidoc:
     neo4j-buildnumber: '4.4'
     driver-version: "4.4"
     javascript-driver-version: "4.4.0"
-    javascript-examples: 'partial$driver-sources/javascript-driver/test'
+    javascript-examples: 'partial$driver-sources/javascript-driver/packages/neo4j-driver/test'

--- a/jsManual/asciidoc/index.adoc
+++ b/jsManual/asciidoc/index.adoc
@@ -13,7 +13,7 @@ endif::[]
 // :example-caption!:
 // :table-caption!:
 ifndef::javascript-root[:javascript-root: {project-root}/build/driver-sources/javascript-driver]
-:javascript-examples: {javascript-root}/test
+:javascript-examples: {javascript-root}/packages/neo4j-driver/test
 :api-docs-base-uri: https://neo4j.com/docs/api
 
 


### PR DESCRIPTION
The driver was restructure internally and the examples now are under 'packages/neo4j/test' insted of 'test'