### PR TITLE
Adding examples for Python's geospatial types

### DIFF
--- a/pythonManual/asciidoc/cypher-workflow.adoc
+++ b/pythonManual/asciidoc/cypher-workflow.adoc
@@ -232,6 +232,44 @@ include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-du
 ----
 
 
+[[python-driver-geospatial-types]]
+=== Geospatial Types
+
+This section lists some basic usage of the geospatial types provided by the Python Driver.
+
+
+[[python-driver-geospatial-types-cartesian]]
+==== `CartesianPoint`
+
+Represents 2 or 3 dimensional point in Cartesian space.
+
+[source, python]
+----
+include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-cartesian-import]
+----
+
+[source, python]
+----
+include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-cartesian]
+----
+
+
+[[python-driver-geospatial-types-wgs84]]
+==== `WGS84Point`
+
+Represents an instant capturing the wgs84, but not the time, nor the timezone.
+
+[source, python]
+----
+include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-wgs84-import]
+----
+
+[source, python]
+----
+include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-wgs84]
+----
+
+
 [[python-driver-exceptions-errors]]
 == Exceptions and error handling
 

--- a/pythonManual/asciidoc/cypher-workflow.adoc
+++ b/pythonManual/asciidoc/cypher-workflow.adoc
@@ -245,12 +245,12 @@ Represents 2 or 3 dimensional point in Cartesian space.
 
 [source, python]
 ----
-include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-cartesian-import]
+include::{python-examples}/test_geospatial_types_example.py[tags=geospatial-types-cartesian-import]
 ----
 
 [source, python]
 ----
-include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-cartesian]
+include::{python-examples}/test_geospatial_types_example.py[tags=geospatial-types-cartesian]
 ----
 
 
@@ -261,13 +261,19 @@ Represents an instant capturing the wgs84, but not the time, nor the timezone.
 
 [source, python]
 ----
-include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-wgs84-import]
+include::{python-examples}/test_geospatial_types_example.py[tags=geospatial-types-wgs84-import]
 ----
 
 [source, python]
 ----
-include::{python-examples}/test_temporal_types_example.py[tags=temporal-types-wgs84]
+include::{python-examples}/test_geospatial_types_example.py[tags=geospatial-types-wgs84]
 ----
+
+
+[[python-driver-exceptions-errors]]
+== Exceptions and error handling
+
+include::{common-content}/cypher-workflow.adoc[tag=exceptions-errors]
 
 
 [[python-driver-exceptions-errors]]


### PR DESCRIPTION
Depending on https://github.com/neo4j/neo4j-python-driver/pull/618

Should also be backported to 4.3, once https://github.com/neo4j/neo4j-python-driver/pull/619 has been merged.