### PR TITLE
Update path to javascript examples in 4.4

### DIFF
--- a/jsManual/antora/antora.yml
+++ b/jsManual/antora/antora.yml
@@ -12,4 +12,4 @@ asciidoc:
     neo4j-buildnumber: '4.4'
     driver-version: "4.4"
     javascript-driver-version: "4.4.0"
-    javascript-examples: 'partial$driver-sources/javascript-driver/test'
+    javascript-examples: 'partial$driver-sources/javascript-driver/packages/neo4j-driver/test'


### PR DESCRIPTION
The examples included in the JavaScript manual have moved in the code repo.

This PR updates the javscript-examples attribute in antora.yml accordingly.