### PR TITLE
Add documentation for Impersonated User session param

### DIFF
--- a/commonManual/asciidoc/session-api.adoc
+++ b/commonManual/asciidoc/session-api.adoc
@@ -754,6 +754,11 @@ In other cases, this setting is inherited. Note that transaction functions will 
 `Database`::
 The database with which the session will interact.
 When you are working with a database which is not the default (i.e. the `system` database or another database in Neo4j 4.0 Enterprise Edition), you can explicitly configure the database which the driver is executing transactions against.
++
+[WARNING]
+====
+Resolution of databases aliases occurs at connection creation time, which is not under the control of the session. It is therefore not recommended altering database aliases while there are live sessions. The per user home-database is resolved at session creation and when first impersonating a user. Therefore, the creation of a new session is necessary to reflect a changed home database.
+====
 See <<operations-manual#manage-databases-default, Operations Manual -> The default database>> for more information on databases.
 +
 *Default:* the default database as configured on the server.
@@ -770,7 +775,8 @@ This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<dr
 # tag::ImpersonatedUser[]
 
 `ImpersonatedUser`::
-Users can run transactions against the database as different users if they have been granted explicit permission for doing it. When impersonating an user, the query is run as the complete security context of the impersonated user and not the authenticated user (e.g. home database, permissions etc).
+Users can run transactions against the database as different users if they have been granted explicit permission for doing so. When impersonating a user, the query is run within the complete security context of the impersonated user and not the authenticated user (i.e., home database, permissions, etc.).
++
 See <<operations-manual#mange-databases-home, Operations Manual -> Per-user home databases>> for more information on default database per user.
 +
 *Default:* None (Sessions will be create with the logged user)

--- a/commonManual/asciidoc/session-api.adoc
+++ b/commonManual/asciidoc/session-api.adoc
@@ -766,3 +766,13 @@ Neo4j 4.0 introduces the ability to pull records in batches, allowing the client
 This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records
+
+# tag::ImpersonatedUser[]
+
+`ImpersonatedUser`::
+Users can run transactions against the database as different users if they have been granted explicit permission for doing it. When impersonating an user, the query is run as the complete security context of the impersonated user and not the authenticated user (e.g. home database, permissions etc).
+See <<operations-manual#mange-databases-home, Operations Manual -> Per-user home databases>> for more information on default database per user.
++
+*Default:* None (Sessions will be create with the logged user)
+
+# end::ImpersonatedUser[]

--- a/commonManual/asciidoc/session-api.adoc
+++ b/commonManual/asciidoc/session-api.adoc
@@ -757,8 +757,12 @@ When you are working with a database which is not the default (i.e. the `system`
 +
 [WARNING]
 ====
-Resolution of databases aliases occurs at connection creation time, which is not under the control of the session. It is therefore not recommended altering database aliases while there are live sessions. The per user home-database is resolved at session creation and when first impersonating a user. Therefore, the creation of a new session is necessary to reflect a changed home database.
+The resolution of database aliases occurs at connection creation time, which is not under the control of the session.
+It is therefore not recommended to alter database aliases while there are live sessions.
+The per-user home database is resolved at session creation and when first impersonating a user.
+Therefore, the creation of a new session is necessary to reflect a changed home database.
 ====
++
 See <<operations-manual#manage-databases-default, Operations Manual -> The default database>> for more information on databases.
 +
 *Default:* the default database as configured on the server.
@@ -775,10 +779,11 @@ This `FetchSize` applies to <<driver-simple-sessions, simple sessions>> and <<dr
 # tag::ImpersonatedUser[]
 
 `ImpersonatedUser`::
-Users can run transactions against the database as different users if they have been granted explicit permission for doing so. When impersonating a user, the query is run within the complete security context of the impersonated user and not the authenticated user (i.e., home database, permissions, etc.).
+Users can run transactions against the database as different users if they have been granted explicit permission for doing so.
+When impersonating a user, the query is run within the complete security context of the impersonated user and not the authenticated user (i.e., home database, permissions, etc.).
 +
-See <<operations-manual#mange-databases-home, Operations Manual -> Per-user home databases>> for more information on default database per user.
+See <<operations-manual#manage-databases-home, Operations Manual -> Per-user home databases>> for more information on default database per-user.
 +
-*Default:* None (Sessions will be create with the logged user)
+*Default:* None (Sessions will be created with the logged user)
 
 # end::ImpersonatedUser[]

--- a/dotnetManual/asciidoc/session-api.adoc
+++ b/dotnetManual/asciidoc/session-api.adoc
@@ -203,3 +203,5 @@ Neo4j 4.0 introduces the ability to pull records in batches, allowing the client
 This `FetchSize` applies to <<dotnet-driver-simple-sessions, simple sessions>> and <<dotnet-driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records
+
+include::{common-content}/session-api.adoc[tag=ImpersonatedUser]

--- a/goManual/asciidoc/session-api.adoc
+++ b/goManual/asciidoc/session-api.adoc
@@ -81,3 +81,5 @@ The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
 +
 *Default:* 1000 records
+
+include::{common-content}/session-api.adoc[tag=ImpersonatedUser]

--- a/javaManual/asciidoc/session-api.adoc
+++ b/javaManual/asciidoc/session-api.adoc
@@ -203,3 +203,5 @@ Neo4j 4.0 introduces the ability to pull records in batches, allowing the client
 This `FetchSize` applies to <<java-driver-simple-sessions, simple sessions>> and <<java-driver-async-sessions, async-sessions>> whereas reactive sessions can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records
+
+include::{common-content}/session-api.adoc[tag=ImpersonatedUser]

--- a/jsManual/asciidoc/session-api.adoc
+++ b/jsManual/asciidoc/session-api.adoc
@@ -139,3 +139,5 @@ Neo4j 4.0 introduces the ability to pull records in batches, allowing the client
 This `FetchSize` applies to <<js-driver-async-sessions, async-sessions>> whereas <<js-driver-rx-sessions, reactive sessions>> can be controlled directly using the request method of the subscription.
 +
 *Default:* 1000 records
+
+include::{common-content}/session-api.adoc[tag=ImpersonatedUser]

--- a/pythonManual/asciidoc/session-api.adoc
+++ b/pythonManual/asciidoc/session-api.adoc
@@ -103,3 +103,5 @@ The number of records to fetch in each batch from the server.
 Neo4j 4.0 introduces the ability to pull records in batches, allowing the client application to take control of data population and apply back pressure to the server.
 +
 *Default:* 1000 records
+
+include::{common-content}/session-api.adoc[tag=ImpersonatedUser]


### PR DESCRIPTION
The impersonation feature impacts two fields in the session configuration, the `database` field which now have get a bit of more contexts about aliases and the `ImpersonatedUser` which is a new session param.

<img width="894" alt="Screenshot 2021-11-18 at 13 30 46" src="https://user-images.githubusercontent.com/1593958/142415890-ca8bb813-ddab-4b76-a809-79cc43ba9c09.png">

The link should points to: https://neo4j.com/docs/operations-manual/4.4/manage-databases/introduction/#mange-databases-home