### PR TITLE
Adding examples for Javascript's geospatial types

### DIFF
--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -199,6 +199,43 @@ Contains both date-based values (years, months, days) and time-based values (sec
 include::{javascript-examples}/examples.test.js[tags=temporal-types-duration]
 ----
 
+[[js-driver-geospatial-types]]
+=== Geospatial Types
+
+This section lists some basic usage of the geospatial types provided by the Javascript Driver.
+
+
+[[js-driver-geospatial-types-cartesian]]
+==== `Point`
+
+Represents 2 or 3 dimensional point in Cartesian space or in the WGS84 space. The field `srid` indicates the type of the coordinate.
+
+The following table defines the list of possibles values for `srid` and its meaning.
+
+======
+[options="header", cols="<20m,<80a"]
+|===
+| SRID        | Description
+| `7203` | 2D point in the cartesian space.
+| `9157` | 3D point in the cartesian space.
+| `4326` | 2D point in the WGS84 space.
+| `4979` | 3D point in the WGS84 space.
+|===
+======
+
+Examples of Cartesian points instantiation and reading:
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=geospatial-types-cartesian]
+----
+
+Examples of WSG84 points instantiation and reading:
+
+[source, javascript]
+----
+include::{javascript-examples}/examples.test.js[tags=geospatial-types-wgs84]
+----
 
 [[js-driver-exceptions-errors]]
 == Exceptions and error handling

--- a/jsManual/asciidoc/cypher-workflow.adoc
+++ b/jsManual/asciidoc/cypher-workflow.adoc
@@ -208,9 +208,10 @@ This section lists some basic usage of the geospatial types provided by the Java
 [[js-driver-geospatial-types-cartesian]]
 ==== `Point`
 
-Represents 2 or 3 dimensional point in Cartesian space or in the WGS84 space. The field `srid` indicates the type of the coordinate.
+Represents 2 or 3 dimensional point in Cartesian space or in the WGS84 space. 
+The field `SRID` indicates the type of the coordinate.
 
-The following table defines the list of possibles values for `srid` and its meaning.
+The following table lists the possible values for `SRID`:
 
 ======
 [options="header", cols="<20m,<80a"]


### PR DESCRIPTION
Depends on: https://github.com/neo4j/neo4j-javascript-driver/pull/816

Preview
![Screenshot 2021-11-24 at 19 34 26](https://user-images.githubusercontent.com/1593958/143295771-ca30ef14-c805-4e28-8d74-adea24569167.png)


