### PR TITLE
Python 4.4 driver requires Python >= 3.6

### DIFF
--- a/commonManual/asciidoc/get-started.adoc
+++ b/commonManual/asciidoc/get-started.adoc
@@ -42,7 +42,7 @@ The following languages and frameworks are officially supported by Neo4j:
 | All LTS versions of Node.JS, specifically the 4.x and 6.x series runtimes (https://github.com/nodejs/LTS).
 
 | Python
-| Python 3.5 and above.
+| Python 3.6 and above.
 |===
 
 The driver API is intended to be topologically agnostic.


### PR DESCRIPTION
Cherry picked from #270 