### PR TITLE
[Python] Improve logging docs

### DIFF
--- a/pythonManual/asciidoc/client-applications.adoc
+++ b/pythonManual/asciidoc/client-applications.adoc
@@ -491,11 +491,29 @@ include::{common-content}/client-applications.adoc[tag=logging]
 
 [source, python]
 ----
+import sys
+
+from neo4j.debug import watch
+
+watch("neo4j", out=sys.stdout)
+----
+
+For more control, you can configure the logger manaully:
+
+[source, python]
+----
 import logging
 import sys
 
+# create a handler, e.g., to log to stdout
 handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
+# configure the handler to your liking
+handler.setFormatter(logging.Formatter(
+    "%(threadName)s(%(thread)d) %(asctime)s  %(message)s"
+))
+# add the handler to the driver's logger
 logging.getLogger("neo4j").addHandler(handler)
+# make sure the logger logs on the desired log level
 logging.getLogger("neo4j").setLevel(logging.DEBUG)
+# from now on, DEBUG logging to stderr is enabled in the driver
 ----


### PR DESCRIPTION
 * add instructions for logging helper (`neo4j.debug.watch`)
 * expanded manual config example to also log the thread name and id.