### PR TITLE
Make Implicit transactions searchable

### DIFF
--- a/common-content/modules/ROOT/partials/session-api.adoc
+++ b/common-content/modules/ROOT/partials/session-api.adoc
@@ -138,11 +138,11 @@ include::{python-examples}/test_transaction_function_example.py[tags=transaction
 
 
 [[driver-simple-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 # tag::simple-autocommit-transactions[]
 
-An auto-commit transaction is a basic but limited form of transaction.
+An auto-commit transaction, or implicit transaction, is a basic but limited form of transaction.
 Such a transaction consists of only one Cypher query and is not automatically retried on failure.
 Therefore, any error scenarios will need to be handled by the client application itself.
 
@@ -392,11 +392,11 @@ include::{javascript-examples}/examples.test.js[tags=async-transaction-function]
 
 
 [[driver-async-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 # tag::async-autocommit-transactions[]
 
-An auto-commit transaction is a basic but limited form of transaction.
+An auto-commit transaction, or implicit transaction, is a basic but limited form of transaction.
 Such a transaction consists of only one Cypher query and is not automatically retried on failure.
 Therefore, any error scenarios will need to be handled by the client application itself.
 
@@ -615,11 +615,11 @@ See xref:session-api.adoc#driver-session-configuration[Session configuration] fo
 
 
 [[driver-rx-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 # tag::rx-autocommit-transactions[]
 
-An auto-commit transaction is a basic but limited form of transaction.
+An auto-commit transaction, or implicit transaction, is a basic but limited form of transaction.
 Such a transaction consists of only one Cypher query and is not automatically retried on failure.
 Therefore, any error scenarios will need to be handled by the client application itself.
 

--- a/dotnet-manual/modules/ROOT/pages/session-api.adoc
+++ b/dotnet-manual/modules/ROOT/pages/session-api.adoc
@@ -39,7 +39,7 @@ include::{dotnet-examples}/Examples.cs[tags=transaction-function]
 
 
 [[dotnet-driver-simple-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=simple-autocommit-transactions]
 
@@ -97,7 +97,7 @@ include::{dotnet-examples}/ExamplesAsync.cs[tags=async-transaction-function]
 
 
 [[dotnet-driver-async-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=async-autocommit-transactions]
 
@@ -161,7 +161,7 @@ See xref:session-api.adoc#dotnet-driver-session-configuration[Session configurat
 
 
 [[dotnet-driver-rx-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=rx-autocommit-transactions]
 

--- a/java-manual/modules/ROOT/pages/session-api.adoc
+++ b/java-manual/modules/ROOT/pages/session-api.adoc
@@ -39,7 +39,7 @@ include::{java-examples}/TransactionFunctionExample.java[tags=transaction-functi
 
 
 [[java-driver-simple-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=simple-autocommit-transactions]
 
@@ -97,7 +97,7 @@ include::{java-examples}/AsyncTransactionFunctionExample.java[tags=async-transac
 
 
 [[java-driver-async-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=async-autocommit-transactions]
 
@@ -161,7 +161,7 @@ See xref:session-api.adoc#java-driver-session-configuration[Session configuratio
 
 
 [[java-driver-rx-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=rx-autocommit-transactions]
 

--- a/javascript-manual/modules/ROOT/pages/session-api.adoc
+++ b/javascript-manual/modules/ROOT/pages/session-api.adoc
@@ -31,7 +31,7 @@ include::{javascript-examples}/examples.test.js[tags=async-transaction-function]
 
 
 [[js-driver-async-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=async-autocommit-transactions]
 
@@ -96,7 +96,7 @@ See xref:session-api.adoc#js-driver-session-configuration[Session configuration]
 
 
 [[js-driver-rx-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=rx-autocommit-transactions]
 

--- a/python-manual/modules/ROOT/pages/session-api.adoc
+++ b/python-manual/modules/ROOT/pages/session-api.adoc
@@ -46,7 +46,7 @@ include::{python-examples}/test_transaction_function_example.py[tags=transaction
 
 
 [[python-driver-simple-autocommit-transactions]]
-=== Auto-commit transactions
+=== Auto-commit transactions (or implicit transactions)
 
 include::{common-partial}/session-api.adoc[tag=simple-autocommit-transactions]
 


### PR DESCRIPTION
FYI @fbiville - I re-raised this on a new PR, as I needed to create a new `5.0` branch.

Adding to the original PR (#294), search is predominantly based on headers, so I've added the "implicit transaction" to both the header and the paragraph.