### PR TITLE
Push glob-parent and antora/site-generator-default version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "overrides": {
     "@antora/site-generator-default": {
-      "glob-parent": "5.1.2"
+      "glob-parent": "6.0.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,15 @@
     "@neo4j-documentation/remote-include": "^1.0.0",
     "js-yaml": "^4.1.0",
     "simple-git": "^3.5.0",
-    "yargs": "^17.5.1",
-    "glob-parent": "^6.0.2",
+    "yargs": "^17.5.1"
   },
   "devDependencies": {
     "express": "^4.17.1",
     "nodemon": "^2.0.15"
+  },
+  "overrides": {
+    "@antora/site-generator-default": {
+      "glob-parent": "5.1.2"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/neo4j/driver-documentation#readme",
   "dependencies": {
     "@antora/cli": "^3.1.0",
-    "@antora/site-generator-default": "^3.1.0",
+    "@antora/site-generator-default": "^3.1.2",
     "@neo4j-antora/antora-add-notes": "^0.1.6",
     "@neo4j-antora/antora-modify-sitemaps": "^0.4.3",
     "@neo4j-antora/antora-page-roles": "^0.3.1",
@@ -36,7 +36,8 @@
     "@neo4j-documentation/remote-include": "^1.0.0",
     "js-yaml": "^4.1.0",
     "simple-git": "^3.5.0",
-    "yargs": "^17.5.1"
+    "yargs": "^17.5.1",
+    "glob-parent": "^6.0.2",
   },
   "devDependencies": {
     "express": "^4.17.1",


### PR DESCRIPTION
Updates `glob-parent` to 6.0.2, the latest release. We need an `override` clause because `antora/site-generator-default` explicitly depends on `glob-parent==3.1.0`, but the update does not seem to break anything. [Changelog](https://github.com/gulpjs/glob-parent/releases) seems quite safe. It should fix the dependabot security alert.
Took the chance to bump `antora/site-generator-default` to `3.1.2`.