### PR TITLE
Add Graphacademy links to Python manual sidebar

### DIFF
--- a/python-manual/modules/ROOT/content-nav.adoc
+++ b/python-manual/modules/ROOT/content-nav.adoc
@@ -19,3 +19,9 @@
 
 * xref:connect-advanced.adoc[Advanced connection information]
 * xref:data-types.adoc[Data types and mapping to Cypher types]
+
+* *GraphAcademy courses*
+
+* link:https://graphacademy.neo4j.com/courses/modeling-fundamentals/[Graph Data Modeling Fundamentals]
+* link:https://graphacademy.neo4j.com/courses/cypher-intermediate-queries/[Intermediate Cypher Queries]
+* link:https://graphacademy.neo4j.com/courses/app-python/[Building Neo4j Applications with Python]


### PR DESCRIPTION
Traditionally there used to be a big badge in the introduction, but that disrupts the reading flow, especially now with the new manual. We don't want to redirect readers away even before starting, and offering the choice of another resource to read would make readers wonder "I am already reading a document titled _Create applications with Neo4j and Python_, why am I seeing an ad for a resource titled _Create Neo4j applications with Python_? Which do I want? Which should I read?" 