### PR TITLE
Changes for Python driver PDF

### DIFF
--- a/python-manual/modules/ROOT/pages/bookmarks.adoc
+++ b/python-manual/modules/ROOT/pages/bookmarks.adoc
@@ -103,8 +103,9 @@ image:{common-image}/driver-passing-bookmarks.svg[]
 The use of bookmarks can negatively impact performance, since all queries are forced to wait for the latest changes to be propagated across the cluster.
 For simple use-cases, try to group queries within a single transaction, or within a single session.
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/concurrency.adoc
+++ b/python-manual/modules/ROOT/pages/concurrency.adoc
@@ -40,8 +40,9 @@ Multithreading is also possible, although `asyncio` is often easier to implement
 There is a known issue with Python 3.8 and the async driver where it gradually slows down.
 It is generally recommended to use the latest supported version of Python for the best performance, stability, and security.
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/connect-advanced.adoc
+++ b/python-manual/modules/ROOT/pages/connect-advanced.adoc
@@ -128,8 +128,9 @@ driver = neo4j.GraphDatabase.driver("neo4j://example.com:9999",
 
 You can find all `Driver` configuration parameters in the link:{neo4j-docs-base-uri}/api/python-driver/current/api.html#driver-configuration[API documentation].
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/connect.adoc
+++ b/python-manual/modules/ROOT/pages/connect.adoc
@@ -40,8 +40,9 @@ Either instantiate the `Driver` object using the `with` statement, or call the `
 
 For more `Driver` configuration parameters and further connection settings, see xref:connect-advanced.adoc[Advanced connection information].
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/data-types.adoc
+++ b/python-manual/modules/ROOT/pages/data-types.adoc
@@ -417,8 +417,9 @@ Examples of such errors are deadlocks and memory issues.
 All driver's exception types implement the method `.is_retryable()`, which gives insights into whether a further attempt might be successful.
 This is particular useful when running queries in xref:transactions#explicit-transactions[explicit transactions], to know if a failed query should be run again.
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/index.adoc
+++ b/python-manual/modules/ROOT/pages/index.adoc
@@ -1,88 +1,33 @@
-:page-toclevels: 0
-
+ifdef::backend-pdf[]
+= The Neo4j Python Driver Manual v{python-driver-version}
+endif::[]
+ifndef::backend-pdf[]
 = Build applications with Neo4j and Python
+:page-toclevels: 0
+endif::[]
 
-The Python driver allows you to connect and interact with a Neo4j database through a Python application.
+// If we are building the PDF, add a heading and include the quickstart information offset by one level 
+ifdef::backend-pdf[]
+== Quickstart
 
-[TIP]
-You need a running Neo4j database to use the driver with it.
-If you do not have one yet, xref:install#get-an-instance[get an instance] for free.
+include::partial$/quickstart.adoc[leveloffset=+1]
+endif::[]
 
-== Installation
-
-Install the Neo4j Python driver with `pip`:
-
-[source,bash]
-----
-pip install neo4j
-----
-
-xref:install#install-driver[More info on installing the driver ->]
+// If we are building HTML, just include the content of the quickstart partial as-is
+ifndef::backend-pdf[]
+include::partial$/quickstart.adoc[]
+endif::[]
 
 
-== Connect to the database
-
-Connect to a database by creating a <<Driver>> object and providing a URL and an authentication token.
-Once you have a `Driver` instance, use the `.verify_connectivity()` method to ensure that a working connection can be established.
-
-[source,python]
-----
-from neo4j import GraphDatabase
-
-# URI examples: "neo4j://localhost", "neo4j+s://xxx.databases.neo4j.io"
-URI = "<URI for Neo4j database>"
-AUTH = ("<Username>", "<Password>")
-
-with GraphDatabase.driver(URI, auth=AUTH) as driver:
-    driver.verify_connectivity()
-----
-
-xref:connect.adoc[More info on connecting to a database ->]
-
-
-== Query the database
-
-Execute a <<Cypher>> statement by creating a session and using the methods `Session.execute_read()` and `Session.execute_write()`.
-Do not hardcode or concatenate parameters: use placeholders and specify the parameters as keyword arguments.
-
-.Get the name of all 42 year-olds
-[source, python, role=nocollapse]
-----
-def match_person_nodes(tx, age):
-    result = tx.run(
-        "MATCH (p:Person {age: $age}) RETURN p.name AS name",
-        age=age)
-    records = list(result)
-    summary = result.consume()
-    return records, summary
-
-with driver.session(database="neo4j") as session:
-    records, summary = session.execute_read(match_person_nodes, age=42)
-
-# Summary information
-print("The query `{query}` returned {records_count} records in {time} ms.".format(
-    query=summary.query, records_count=len(records),
-    time=summary.result_available_after,
-))
-
-# Loop through results and do something with them
-for person in records:
-    print(person)
-----
-
-xref:query-simple.adoc[More info on querying the database ->]
-
-
-== Close connections and sessions
-
-Unless you created them using the `with` statement, call the `.close()` method on all `Driver` and `Session` instances to release any resources still held by them.
-
-[source,python]
-session.close()
-driver.close()
-
+ifdef::backend-pdf[]
+<<<
+endif::[]
 
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+
+ifdef::backend-pdf[]
+<<<
+endif::[]

--- a/python-manual/modules/ROOT/pages/index.adoc
+++ b/python-manual/modules/ROOT/pages/index.adoc
@@ -23,7 +23,9 @@ ifdef::backend-pdf[]
 <<<
 endif::[]
 
+ifndef::backend-pdf[]
 [discrete.glossary]
+endif::[]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]

--- a/python-manual/modules/ROOT/pages/install.adoc
+++ b/python-manual/modules/ROOT/pages/install.adoc
@@ -42,8 +42,9 @@ Take a note of the connection URI and of the login credentials.
 
 You can also link:https://neo4j.com/download-center/#community[install Neo4j on your system], or use link:https://neo4j.com/download-center/#desktop[Neo4j Desktop] to create a local development environment (not for production).
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/performance.adoc
+++ b/python-manual/modules/ROOT/pages/performance.adoc
@@ -163,8 +163,9 @@ This is likely to be more impactful on performance if you parallelize complex an
 
 // - with SET, specify individual properties one by one instead of using += (too low impact)
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/query-advanced.adoc
+++ b/python-manual/modules/ROOT/pages/query-advanced.adoc
@@ -119,8 +119,9 @@ CALL {
 ----
 ////
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/query-simple.adoc
+++ b/python-manual/modules/ROOT/pages/query-simple.adoc
@@ -258,8 +258,9 @@ with GraphDatabase.driver(URI, auth=AUTH) as driver:
             print(person.data())  # get a dict view
 ----
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/result.adoc
+++ b/python-manual/modules/ROOT/pages/result.adoc
@@ -251,8 +251,9 @@ if __name__ == "__main__":
 .Graph visualization of example above
 image::{common-image}/pyvis-example.png[]
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/pages/transactions.adoc
+++ b/python-manual/modules/ROOT/pages/transactions.adoc
@@ -333,8 +333,9 @@ session = driver.session(database="neo4j")
 session.close()
 ----
 
-
+ifndef::backend-pdf[]
 [discrete.glossary]
 == Glossary
 
 include::{common-partial}/glossary.adoc[]
+endif::[]

--- a/python-manual/modules/ROOT/partials/quickstart.adoc
+++ b/python-manual/modules/ROOT/partials/quickstart.adoc
@@ -1,0 +1,74 @@
+== Installation
+
+Install the Neo4j Python driver with `pip`:
+
+[source,bash]
+----
+pip install neo4j
+----
+
+xref:install#install-driver[More info on installing the driver ->]
+
+
+== Connect to the database
+
+Connect to a database by creating a <<Driver>> object and providing a URL and an authentication token.
+Once you have a `Driver` instance, use the `.verify_connectivity()` method to ensure that a working connection can be established.
+
+[source,python]
+----
+from neo4j import GraphDatabase
+
+# URI examples: "neo4j://localhost", "neo4j+s://xxx.databases.neo4j.io"
+URI = "<URI for Neo4j database>"
+AUTH = ("<Username>", "<Password>")
+
+with GraphDatabase.driver(URI, auth=AUTH) as driver:
+    driver.verify_connectivity()
+----
+
+xref:connect.adoc[More info on connecting to a database ->]
+
+
+== Query the database
+
+Execute a <<Cypher>> statement by creating a session and using the methods `Session.execute_read()` and `Session.execute_write()`.
+Do not hardcode or concatenate parameters: use placeholders and specify the parameters as keyword arguments.
+
+.Get the name of all 42 year-olds
+[source, python, role=nocollapse]
+----
+def match_person_nodes(tx, age):
+    result = tx.run(
+        "MATCH (p:Person {age: $age}) RETURN p.name AS name",
+        age=age)
+    records = list(result)
+    summary = result.consume()
+    return records, summary
+
+with driver.session(database="neo4j") as session:
+    records, summary = session.execute_read(match_person_nodes, age=42)
+
+# Summary information
+print("The query `{query}` returned {records_count} records in {time} ms.".format(
+    query=summary.query, records_count=len(records),
+    time=summary.result_available_after,
+))
+
+# Loop through results and do something with them
+for person in records:
+    print(person)
+----
+
+xref:query-simple.adoc[More info on querying the database ->]
+
+
+== Close connections and sessions
+
+Unless you created them using the `with` statement, call the `.close()` method on all `Driver` and `Session` instances to release any resources still held by them.
+
+[source,python]
+session.close()
+driver.close()
+
+


### PR DESCRIPTION
Makes some changes for the Python Driver PDF, by using conditionals.

- Uses the standard PDF document title
- Moves the quickstart content into a partial so it can be included with `leveloffset` in the PDF.
- Adds a conditional for each glossary instance so they are not output for every section in the PDF. The glossary is included once in the PDF.