### PR TITLE
Remove context routing in favor of updated load balancing policies one

### DIFF
--- a/common-content/modules/ROOT/partials/client-applications.adoc
+++ b/common-content/modules/ROOT/partials/client-applications.adoc
@@ -245,44 +245,20 @@ The driver does not expose any API to work directly with the routing table, but 
 # end::routing-table[]
 
 
-[[driver-routing-context]]
-=== Routing context
+=== Load balancing policies
 
-# tag::routing-context[]
+# tag::load-balancing-policies[]
 
-A routing context can be included as the query part of a `neo4j://` URI.
+A `policy` parameter can be included in the query string of a `neo4j://` URI, to customize the routing table and take advantage of link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/clustering-advanced/multi-data-center-routing/[multi-data center routing settings].
 
-Routing contexts are defined by means of *_server policies_* and allow customization of the contents of the routing table.
-
-.Configure a routing driver with routing context
-====
-This example will assume that *Neo4j* has been configured for server policies as described in link:/docs/operations-manual/5.0/clustering-advanced/multi-data-center/load-balancing[Neo4j Operations Manual -> Load balancing for multi-data center systems].
-In particular, a server policy called `europe` has been defined.
-Additionally, we have a server `neo01.graph.example.com` to which we wish to direct the driver.
-
-This URI will use the server policy `europe`:
-
-`neo4j://neo01.graph.example.com?policy=europe`
-====
+For example, if Neo4j is configured with a _link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/clustering-advanced/multi-data-center-routing/#mdc-server-tags[server tag]_ called `europe`, the parameter `policy=europe` can be appended to the connection URI to enforce usage of that tag. In practice, if the server is reachable at `neo01.graph.example.com`, the URI with server policy `europe` is `neo4j://neo01.graph.example.com?policy=europe`.
 
 [NOTE]
-.Server-side configuration to enable routing drivers with routing context
 ====
-A prerequisite for using a routing driver with routing context is that the *Neo4j* database is operated on a link:/docs/operations-manual/5.0/clustering[Causal Cluster] with the link:/docs/operations-manual/5.0/clustering-advanced/multi-data-center[Multi-data center licensing option] enabled.
-Additionally, the routing contexts must be defined within the cluster as *_routing policies_*.
-
-For details on how to configure *_multi-data center routing policies_* for a Causal Cluster, please refer to link:/docs/operations-manual/5.0/clustering-advanced/multi-data-center/load-balancing[Operations Manual -> Causal Clustering].
+A prerequisite for using load balancing policies with the driver is that the database is operated on a link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering[cluster], and that some link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/clustering-advanced/multi-data-center-routing/#mdc-policy-definitions[server policies] are set up.
 ====
 
-[NOTE]
-.Exposing a single instance deployment on a remote host using the `neo4j` URI scheme
-====
-If you are using a *_single instance_* of *Neo4j*, deployed on a remote machine whilst using the `neo4j` URI scheme, *_you will need to complete additional configuration of the server_*.
-
-To make the server aware of its deployment environment, you need to configure link:/docs/operations-manual/5.0/reference/configuration-settings/#config_server.default_advertised_address[`default_advertised_address`] with your deployment machine's host name, as visible from the client machine.
-====
-
-# end::routing-context[]
+# end::load-balancing-policies[]
 
 
 [[driver-configuration-examples]]

--- a/common-content/modules/ROOT/partials/client-applications.adoc
+++ b/common-content/modules/ROOT/partials/client-applications.adoc
@@ -268,9 +268,9 @@ A prerequisite for using load balancing policies with the driver is that the dat
 
 *_Connection URIs_* are typically formed according to the following pattern:
 
-[source, shell, indent=0]
+[source, shell]
 ----
-neo4j://<HOST>:<PORT>[?<ROUTING_CONTEXT>]
+neo4j://<HOST>:<PORT>[?policy=<POLICY-NAME>]
 ----
 
 This targets a routed *Neo4j* service that may be fulfilled by either a cluster or a single instance.

--- a/dotnet-manual/modules/ROOT/pages/client-applications.adoc
+++ b/dotnet-manual/modules/ROOT/pages/client-applications.adoc
@@ -81,7 +81,6 @@ include::{dotnet-examples}/Examples.cs[tags=config-custom-resolver]
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[dotnet-driver-load-balancing-policies]]
 === Load balancing policies
 
 include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
@@ -93,7 +92,7 @@ include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 include::{common-partial}/client-applications.adoc[tag=examples-pt1]
 
 In a clustered environment, the URI address will resolve to one of more of the core members; for standalone installations, this will simply point to that server address.
-The `ROUTING_CONTEXT` option allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#dotnet-driver-routing-context[Routing context].
+The `policy` parameter allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#_load_balancing_policies[load balancing policies].
 
 include::{common-partial}/client-applications.adoc[tag=examples-pt2]
 

--- a/dotnet-manual/modules/ROOT/pages/client-applications.adoc
+++ b/dotnet-manual/modules/ROOT/pages/client-applications.adoc
@@ -81,10 +81,10 @@ include::{dotnet-examples}/Examples.cs[tags=config-custom-resolver]
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[dotnet-driver-routing-context]]
-=== Routing context
+[[dotnet-driver-load-balancing-policies]]
+=== Load balancing policies
 
-include::{common-partial}/client-applications.adoc[tag=routing-context]
+include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 
 
 [[dotnet-driver-configuration-examples]]

--- a/go-manual/modules/ROOT/pages/client-applications.adoc
+++ b/go-manual/modules/ROOT/pages/client-applications.adoc
@@ -75,7 +75,6 @@ include::{go-examples}/examples_test.go[tags=config-custom-resolver]
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[go-driver-load-balancing-policies]]
 === Load balancing policies
 
 include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
@@ -87,7 +86,7 @@ include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 include::{common-partial}/client-applications.adoc[tag=examples-pt1]
 
 In a clustered environment, the URI address will resolve to one of more of the core members; for standalone installations, this will simply point to that server address.
-The `ROUTING_CONTEXT` option allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#go-driver-routing-context[Routing context].
+The `policy` parameter allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#_load_balancing_policies[load balancing policies].
 
 include::{common-partial}/client-applications.adoc[tag=examples-pt2]
 

--- a/go-manual/modules/ROOT/pages/client-applications.adoc
+++ b/go-manual/modules/ROOT/pages/client-applications.adoc
@@ -75,10 +75,10 @@ include::{go-examples}/examples_test.go[tags=config-custom-resolver]
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[go-driver-routing-context]]
-=== Routing context
+[[go-driver-load-balancing-policies]]
+=== Load balancing policies
 
-include::{common-partial}/client-applications.adoc[tag=routing-context]
+include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 
 
 [[go-driver-configuration-examples]]

--- a/java-manual/modules/ROOT/pages/client-applications.adoc
+++ b/java-manual/modules/ROOT/pages/client-applications.adoc
@@ -82,10 +82,10 @@ include::{java-examples}/ConfigCustomResolverExample.java[tags=config-custom-res
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[java-driver-routing-context]]
-=== Routing context
+[[java-driver-load-balancing-policies]]
+=== Load balancing policies
 
-include::{common-partial}/client-applications.adoc[tag=routing-context]
+include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 
 
 [[java-driver-configuration-examples]]

--- a/java-manual/modules/ROOT/pages/client-applications.adoc
+++ b/java-manual/modules/ROOT/pages/client-applications.adoc
@@ -82,7 +82,6 @@ include::{java-examples}/ConfigCustomResolverExample.java[tags=config-custom-res
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[java-driver-load-balancing-policies]]
 === Load balancing policies
 
 include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]

--- a/java-manual/modules/ROOT/pages/client-applications.adoc
+++ b/java-manual/modules/ROOT/pages/client-applications.adoc
@@ -88,13 +88,12 @@ include::{common-partial}/client-applications.adoc[tag=routing-table]
 include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 
 
-[[java-driver-configuration-examples]]
 === Examples
 
 include::{common-partial}/client-applications.adoc[tag=examples-pt1]
 
 In a clustered environment, the URI address will resolve to one of more of the core members; for standalone installations, this will simply point to that server address.
-The `ROUTING_CONTEXT` option allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#java-driver-routing-context[Routing context].
+The `policy` parameter allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#_load_balancing_policies[load balancing policies].
 
 include::{common-partial}/client-applications.adoc[tag=examples-pt2]
 

--- a/javascript-manual/modules/ROOT/pages/client-applications.adoc
+++ b/javascript-manual/modules/ROOT/pages/client-applications.adoc
@@ -82,10 +82,10 @@ include::{javascript-examples}/examples.test.js[tags=config-custom-resolver]
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[js-driver-routing-context]]
-=== Routing context
+[[js-driver-load-balancing-policies]]
+=== Load balancing policies
 
-include::{common-partial}/client-applications.adoc[tag=routing-context]
+include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 
 
 [[js-driver-configuration-examples]]

--- a/javascript-manual/modules/ROOT/pages/client-applications.adoc
+++ b/javascript-manual/modules/ROOT/pages/client-applications.adoc
@@ -82,7 +82,6 @@ include::{javascript-examples}/examples.test.js[tags=config-custom-resolver]
 include::{common-partial}/client-applications.adoc[tag=routing-table]
 
 
-[[js-driver-load-balancing-policies]]
 === Load balancing policies
 
 include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
@@ -94,7 +93,7 @@ include::{common-partial}/client-applications.adoc[tag=load-balancing-policies]
 include::{common-partial}/client-applications.adoc[tag=examples-pt1]
 
 In a clustered environment, the URI address will resolve to one of more of the core members; for standalone installations, this will simply point to that server address.
-The `ROUTING_CONTEXT` option allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#js-driver-routing-context[Routing context].
+The `policy` parameter allows for customization of the routing table and is discussed in more detail in xref:client-applications.adoc#_load_balancing_policies[load balancing policies].
 
 include::{common-partial}/client-applications.adoc[tag=examples-pt2]
 


### PR DESCRIPTION
This changed in v5.