### PR TITLE
[Javascript] FIX: serverInfo is not defined and using getServerInfo since verifyConnectivity is deprecated

### DIFF
--- a/javascript-manual/modules/ROOT/partials/quickstart.adoc
+++ b/javascript-manual/modules/ROOT/partials/quickstart.adoc
@@ -30,7 +30,7 @@ var neo4j = require('neo4j-driver');
 
   try {
     driver = neo4j.driver(URI,  neo4j.auth.basic(USER, PASSWORD))
-    await driver.verifyConnectivity()
+    const serverInfo = await driver.getServerInfo()
     console.log('Connection estabilished')
     console.log(serverInfo)
   } catch(err) {


### PR DESCRIPTION
The quickstart example for JavaScript references an undeclared variable `serverInfo`.

It also uses a deprecated function `verifyConnectivity()`. Using the recommended function `getServerInfo()` instead.