### PR TITLE
Update information about tx timeout

### DIFF
--- a/common-content/modules/ROOT/partials/session-api.adoc
+++ b/common-content/modules/ROOT/partials/session-api.adoc
@@ -822,13 +822,14 @@ Additional configuration can be provided to transaction which are executed.
 === Transaction timeout
 
 A timeout value can be provided and transactions which take longer than this value to execute on the server will be terminated.
-This value will override the value set by `+dbms.transaction.timeout+`. If no value is provided, the default is taken by the server setting
+This value will override the value set by `+dbms.transaction.timeout+`.
+If no value is provided, the default is taken by the server setting
 (see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/monitoring/transaction-management[Operations Manual -> Transaction Management]).
 
-Note: Using with Neo4j 4.1 and earlier it is possible for the driver to override any value set with `+dbms.transaction.timeout+`.
-In 4.2 and later, `+dbms.transaction.timeout+` also acts as a maximum which the driver cannot override. For example, with
-a server setting of `+dbms.transaction.timeout=10s+` the driver can specify a shorter timeout (e.g. 5 seconds) but not a value
-greater than 10 seconds. If a greater value is supplied the transaction will still timeout after 10 seconds.
+Note: In the context of Neo4j versions 4.2 through 5.2, `+dbms.transaction.timeout+` acts as a maximum that the driver cannot override.
+For example, with a server setting of `+dbms.transaction.timeout=10s+` the driver can specify a shorter timeout (e.g., 5 seconds) but not a value greater than 10 seconds.
+If a greater value is supplied the transaction will still timeout after 10 seconds.
+In Neo4j 5.3 and later releases, you can set transaction timeout to any value you wish, and it is possible for the driver to override any value set with `+dbms.transaction.timeout+`.
 
 *Default:* Configured on server with `+dbms.transaction.timeout+`.
 


### PR DESCRIPTION
My solution is not ideal, but I think we can allow ourselves not to mention versions earlier than 4.2 as they are EOL, and we actually support only 4.4.x and 5.x series.