### PR TITLE
Removing extra /docs/ in url (#426)

### DIFF
--- a/common-content/modules/ROOT/partials/connect-advanced.adoc
+++ b/common-content/modules/ROOT/partials/connect-advanced.adoc
@@ -12,7 +12,7 @@ The driver supports connection to URIs of the form
 - `<SCHEME>` is one among `neo4j`, `neo4j+s`, `neo4j+ssc`, `bolt`, `bolt+s`, `bolt+ssc`.
 - `<HOST>` is the host name where the Neo4j server is located.
 - `<PORT>` is optional, and denotes the port the <<Bolt>> protocol is available at.
-- `<POLICY-NAME>` is an optional _server policy_ name. link:{neo4j-docs-base-uri}/docs/operations-manual/current/clustering/clustering-advanced/multi-data-center-routing/[Server policies] need to be set up prior to usage.
+- `<POLICY-NAME>` is an optional _server policy_ name. link:{neo4j-docs-base-uri}/operations-manual/current/clustering/clustering-advanced/multi-data-center-routing/[Server policies] need to be set up prior to usage.
 
 [NOTE]
 The driver does not support connection to a nested path, such as `example.com/neo4j/`.


### PR DESCRIPTION
Cherry-picked from https://github.com/neo4j/docs-drivers/pull/426