### PR TITLE
Fixing redirect loops

### DIFF
--- a/go-manual/modules/ROOT/pages/transactions.adoc
+++ b/go-manual/modules/ROOT/pages/transactions.adoc
@@ -481,7 +481,7 @@ Similar remarks hold for the `.ExecuteRead()` and `.ExecuteWrite()` methods.
 === Run queries as a different user (impersonation)
 
 You can execute a query under the security context of a different user with the configuration parameter `ImpersonatedUser`, specifying the name of the user to impersonate.
-For this to work, the user under which the `DriverWithContext` was created needs to have the link:{neo4j-docs-base-uri}/cypher-manual/current/access-control/dbms-administration#access-control-dbms-administration-impersonation[appropriate permissions].
+For this to work, the user under which the `DriverWithContext` was created needs to have the link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/dbms-administration/#access-control-dbms-administration-impersonation[appropriate permissions].
 Impersonating a user is cheaper than creating a new `DriverWithContext` object.
 
 [source, go]

--- a/java-manual/modules/ROOT/pages/transactions.adoc
+++ b/java-manual/modules/ROOT/pages/transactions.adoc
@@ -441,7 +441,7 @@ Similar remarks hold for the `.executeRead()` and `.executeWrite()` methods.
 === Run queries as a different user (impersonation)
 
 You can execute a query under the security context of a different user with the method `.withImpersonatedUser("<username>")`, specifying the name of the user to impersonate.
-For this to work, the user under which the `Driver` was created needs to have the link:{neo4j-docs-base-uri}/cypher-manual/current/access-control/dbms-administration#access-control-dbms-administration-impersonation[appropriate permissions].
+For this to work, the user under which the `Driver` was created needs to have the link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/dbms-administration/#access-control-dbms-administration-impersonation[appropriate permissions].
 Impersonating a user is cheaper than creating a new `Driver` object.
 
 [source, java]

--- a/javascript-manual/modules/ROOT/pages/transactions.adoc
+++ b/javascript-manual/modules/ROOT/pages/transactions.adoc
@@ -323,7 +323,7 @@ Similar remarks hold for the `.executeRead()` and `.executeWrite()` methods.
 === Run queries as a different user (impersonation)
 
 You can execute a query under the security context of a different user with the parameter `impersonatedUser`, specifying the name of the user to impersonate.
-For this to work, the user under which the `Driver` was created needs to have the link:{neo4j-docs-base-uri}/cypher-manual/current/access-control/dbms-administration#access-control-dbms-administration-impersonation[appropriate permissions].
+For this to work, the user under which the `Driver` was created needs to have the link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/dbms-administration/#access-control-dbms-administration-impersonation[appropriate permissions].
 Impersonating a user is cheaper than creating a new `Driver` object.
 
 [source, javascript]

--- a/python-manual/modules/ROOT/pages/transactions.adoc
+++ b/python-manual/modules/ROOT/pages/transactions.adoc
@@ -391,7 +391,7 @@ Similar remarks hold for the `.executeRead()` and `.executeWrite()` methods.
 === Run queries as a different user (impersonation)
 
 You can execute a query under the security context of a different user with the parameter `impersonated_user`, specifying the name of the user to impersonate.
-For this to work, the user under which the `Driver` was created needs to have the link:{neo4j-docs-base-uri}/cypher-manual/current/access-control/dbms-administration#access-control-dbms-administration-impersonation[appropriate permissions].
+For this to work, the user under which the `Driver` was created needs to have the link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/dbms-administration/#access-control-dbms-administration-impersonation[appropriate permissions].
 Impersonating a user is cheaper than creating a new `Driver` object.
 
 [source, python]


### PR DESCRIPTION
SEMRush flagged a redirect loop from this link that was once in the Cypher manual, but now it's in the Operations manual. Although this doesn't create any errors in navigation, it's bad for search engines crawling.