### PR TITLE
Add index page for local preview

### DIFF
--- a/create-applications/antora.yml
+++ b/create-applications/antora.yml
@@ -1,0 +1,6 @@
+name: create-applications
+title: Neo4j Drivers
+version: '5'
+start_page: ROOT:index.adoc
+nav:
+- modules/ROOT/content-nav.adoc

--- a/create-applications/modules/ROOT/content-nav.adoc
+++ b/create-applications/modules/ROOT/content-nav.adoc
@@ -1,0 +1,1 @@
+* xref:index.adoc[]

--- a/create-applications/modules/ROOT/pages/index.adoc
+++ b/create-applications/modules/ROOT/pages/index.adoc
@@ -1,0 +1,78 @@
+= Create applications with Neo4j
+:page-role: create-applications
+:page-layout: docs-home
+:page-toclevels: -1
+
+
+
+[NOTE]
+--
+This page is published only as part of local builds and PR previews.
+It is not included in the published Neo4j drivers documentation.
+--
+
+
+[.display]
+== Language libraries
+
+
+=== Neo4j Python Driver
+
+[.category]
+Drivers
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/python-logo.svg[]
+
+[.link]
+xref:python-manual:ROOT:index.adoc[Guide]
+
+
+=== Neo4j Go Driver
+
+[.category]
+Drivers
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/go-logo.svg[]
+
+[.link]
+xref:go-manual:ROOT:index.adoc[Guide]
+
+
+=== Neo4j Java Driver
+
+[.category]
+Drivers
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/java-logo.svg[]
+
+[.link]
+xref:java-manual:ROOT:index.adoc[Guide]
+
+
+=== Neo4j JavaScript Driver
+
+[.category]
+Drivers
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/js-logo.svg[]
+
+[.link]
+xref:javascript-manual:ROOT:index.adoc[Guide]
+
+
+=== Neo4j .NET Driver
+
+[.category]
+Drivers
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/dotnet-logo.svg[]
+
+[.link]
+xref:dotnet-manual:ROOT:index.adoc[Guide]
+
+

--- a/preview.yml
+++ b/preview.yml
@@ -1,7 +1,7 @@
 site:
   title: Neo4j Docs
   url: https://neo4j.com/docs
-#  start_page: python-manual::index.adoc
+  start_page: create-applications::index.adoc
 
 content:
   sources:
@@ -9,6 +9,7 @@ content:
     branches: ['HEAD']
     edit_url: https://github.com/neo4j/docs-drivers/tree/{refname}/{path}
     start_paths:
+    - create-applications
     - go-manual
     - javascript-manual
     - python-manual


### PR DESCRIPTION
Added a new index page that can be used as the `start_page` in the preview playbook.

The page uses the same style and path as the Create Applications page at neo4j.com/docs/create-applications/.

This ensures that localhost:8000 returns a useful page when building local and PR preview.
