### PR TITLE
Move `Profile queries` performance section into partial, remove examples

### DIFF
--- a/common-content/modules/ROOT/partials/performance.adoc
+++ b/common-content/modules/ROOT/partials/performance.adoc
@@ -1,0 +1,13 @@
+# tag::profile-queries[]
+
+[#profile-queries]
+== Profile queries
+
+link:++https://neo4j.com/docs/cypher-manual/current/appendix/tutorials/basic-query-tuning/#_profile_query++[Profile your queries] to locate queries whose performance can be improved.
+You can profile queries by prepending them with `PROFILE`.
+In case some queries are so slow that you are unable to even run them in reasonable times, you can prepend them with `EXPLAIN` instead of `PROFILE`.
+This will return the plan that the server would use to run the query, but without executing it.
+
+For more information, see xref:result-summary.adoc#execution-plan[Explore the query execution summary -> Query execution plan].
+
+# end::profile-queries[]

--- a/dotnet-manual/modules/ROOT/pages/performance.adoc
+++ b/dotnet-manual/modules/ROOT/pages/performance.adoc
@@ -307,73 +307,7 @@ await driver.ExecutableQuery("CREATE INDEX person_name FOR (n:Person) ON (n.name
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes/search-performance-indexes/overview/[Indexes for search performance].
 
 
-[[profile-queries]]
-== Profile queries
-
-link:{neo4j-docs-base-uri}/cypher-manual/current/query-tuning/basic-example/#_profile_query[*Profile your queries*] to locate queries whose performance can be improved.
-You can profile queries by prepending them with `PROFILE`.
-The server output is available in the `Profile` property of the xref:result-summary.adoc[`IResultSummary`] object.
-
-[source, csharp]
-----
-var result = await driver.ExecutableQuery("PROFILE MATCH (p {name: $name}) RETURN p")
-    .WithParameters(new { name = "Alice" })
-    .WithConfig(new QueryConfig(database: "<database-name>"))
-    .ExecuteAsync();
-// Note: `result.Result` is non-empty
-var queryPlan = result.Summary.Profile;
-Console.WriteLine(queryPlan.Arguments["string-representation"]);
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator        | Details        | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults | p              |              1 |    1 |       3 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter         | p.name = $name |              1 |    1 |       4 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +AllNodesScan   | p              |             10 |    4 |       5 |            120 |                 9160/0 |   108.923 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-
-Total database accesses: 12, total allocated memory: 184
-*/
-----
-
-In case some queries are so slow that you are unable to even run them in reasonable times, you can prepend them with `EXPLAIN` instead of `PROFILE`.
-This will return the _plan_ that the server would use to run the query, but without executing it.
-The server output is available in the `Plan` property of the xref:result-summary.adoc[`IResultSummary`] object.
-
-[source, csharp]
-----
-var result = await driver.ExecutableQuery("EXPLAIN MATCH (p {name: $name}) RETURN p")
-    .WithParameters(new { name = "Alice" })
-    .WithConfig(new QueryConfig(database: "<database-name>"))
-    .ExecuteAsync();
-var queryPlan = result.Summary.Plan;
-Console.WriteLine(queryPlan.Arguments["string-representation"]);
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+---------------------+
-| Operator        | Details        | Estimated Rows | Pipeline            |
-+-----------------+----------------+----------------+---------------------+
-| +ProduceResults | p              |              1 |                     |
-| |               +----------------+----------------+                     |
-| +Filter         | p.name = $name |              1 |                     |
-| |               +----------------+----------------+                     |
-| +AllNodesScan   | p              |             10 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+---------------------+
-
-Total database accesses: ?
-*/
-----
+include::{common-partial}/performance.adoc[tag=profile-queries]
 
 
 [[node-labels]]

--- a/go-manual/modules/ROOT/pages/performance.adoc
+++ b/go-manual/modules/ROOT/pages/performance.adoc
@@ -355,76 +355,7 @@ neo4j.ExecuteQuery(ctx, driver,
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance/[Indexes for search performance].
 
 
-[[profile-queries]]
-== Profile queries
-
-link:https://neo4j.com/docs/cypher-manual/current/appendix/tutorials/basic-query-tuning/#_profile_query[*Profile your queries*] to locate queries whose performance can be improved.
-You can profile queries by prepending them with `PROFILE`.
-The server output is available through the `.Profile()` method on the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, go, role=nocollapse]
-----
-result, _ := neo4j.ExecuteQuery(ctx, driver,
-    "PROFILE MATCH (p {name: $name}) RETURN p",
-    map[string]any{
-        "name": "Alice",
-    },
-    neo4j.EagerResultTransformer,
-    neo4j.ExecuteQueryWithDatabase("<database-name>"))
-fmt.Println(result.Summary.Profile().Arguments()["string-representation"])
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator        | Details        | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults | p              |              1 |    1 |       3 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter         | p.name = $name |              1 |    1 |       4 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +AllNodesScan   | p              |             10 |    4 |       5 |            120 |                 9160/0 |   108.923 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-
-Total database accesses: 12, total allocated memory: 184
-*/
-----
-
-In case some queries are so slow that you are unable to even run them in reasonable times, you can prepend them with `EXPLAIN` instead of `PROFILE`.
-This will return the _plan_ that the server would use to run the query, but without executing it.
-The server output is available through the `.Plan()` method on the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, go, role=nocollapse]
-----
-result, _ := neo4j.ExecuteQuery(ctx, driver,
-    "EXPLAIN MATCH (p {name: $name}) RETURN p",
-    map[string]any{
-        "name": "Alice",
-    },
-    neo4j.EagerResultTransformer,
-    neo4j.ExecuteQueryWithDatabase("<database-name>"))
-fmt.Println(result.Summary.Plan().Arguments()["string-representation"])
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+---------------------+
-| Operator        | Details        | Estimated Rows | Pipeline            |
-+-----------------+----------------+----------------+---------------------+
-| +ProduceResults | p              |              1 |                     |
-| |               +----------------+----------------+                     |
-| +Filter         | p.name = $name |              1 |                     |
-| |               +----------------+----------------+                     |
-| +AllNodesScan   | p              |             10 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+---------------------+
-
-Total database accesses: ?
-*/
-----
+include::{common-partial}/performance.adoc[tag=profile-queries]
 
 
 [[node-labels]]

--- a/go-manual/modules/ROOT/pages/result-summary.adoc
+++ b/go-manual/modules/ROOT/pages/result-summary.adoc
@@ -77,6 +77,7 @@ Two additional boolean methods act as meta-counters:
 - `.ContainsSystemUpdates()` -- whether the query triggered any write operation on the `system` database
 
 
+[#execution-plan]
 == Query execution plan
 
 If you prefix a query with `EXPLAIN`, the server returns the plan it _would_ use to run the query, but does not actually run it.

--- a/java-manual/modules/ROOT/pages/performance.adoc
+++ b/java-manual/modules/ROOT/pages/performance.adoc
@@ -166,74 +166,7 @@ driver.executableQuery("CREATE INDEX person_name FOR (n:Person) ON (n.name)").ex
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance/[Indexes for search performance].
 
 
-[[profile-queries]]
-== Profile queries
-
-link:https://neo4j.com/docs/cypher-manual/current/appendix/tutorials/basic-query-tuning/#_profile_query[*Profile your queries*] to locate queries whose performance can be improved.
-You can profile queries by prepending them with `PROFILE`.
-The server output is available through the `.profile()` method of the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, java]
-----
-var result = driver.executableQuery("PROFILE MATCH (p {name: $name}) RETURN p")
-    .withParameters(Map.of("name", "Alice"))
-    .withConfig(QueryConfig.builder().withDatabase("<database-name>").build())
-    .execute();
-var queryPlan = result.summary().profile().arguments().get("string-representation");
-System.out.println(queryPlan);
-
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator        | Details        | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults | p              |              1 |    1 |       3 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter         | p.name = $name |              1 |    1 |       4 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +AllNodesScan   | p              |             10 |    4 |       5 |            120 |                 9160/0 |   108.923 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-
-Total database accesses: 12, total allocated memory: 184
-*/
-----
-
-In case some queries are so slow that you are unable to even run them in reasonable times, you can prepend them with `EXPLAIN` instead of `PROFILE`.
-This will return the _plan_ that the server would use to run the query, but without executing it.
-The server output is available through the `.plan()` method of the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, java]
-----
-var result = driver.executableQuery("EXPLAIN MATCH (p {name: $name}) RETURN p")
-    .withParameters(Map.of("name", "Alice"))
-    .withConfig(QueryConfig.builder().withDatabase("<database-name>").build())
-    .execute();
-var queryPlan = result.summary().plan().arguments().get("string-representation");
-System.out.println(queryPlan);
-
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+---------------------+
-| Operator        | Details        | Estimated Rows | Pipeline            |
-+-----------------+----------------+----------------+---------------------+
-| +ProduceResults | p              |              1 |                     |
-| |               +----------------+----------------+                     |
-| +Filter         | p.name = $name |              1 |                     |
-| |               +----------------+----------------+                     |
-| +AllNodesScan   | p              |             10 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+---------------------+
-
-Total database accesses: ?
-*/
-----
+include::{common-partial}/performance.adoc[tag=profile-queries]
 
 
 [[node-labels]]

--- a/java-manual/modules/ROOT/pages/result-summary.adoc
+++ b/java-manual/modules/ROOT/pages/result-summary.adoc
@@ -70,6 +70,7 @@ Two additional boolean methods act as meta-counters:
 - `.containsSystemUpdates()` -- Whether the query triggered any write operation on the `system` database
 
 
+[#execution-plan]
 == Query execution plan
 
 If you prefix a query with `EXPLAIN`, the server returns the plan it _would_ use to run the query, but doesn't actually run it.

--- a/javascript-manual/modules/ROOT/pages/performance.adoc
+++ b/javascript-manual/modules/ROOT/pages/performance.adoc
@@ -158,64 +158,7 @@ await driver.executeQuery('CREATE INDEX personName FOR (n:Person) ON (n.name)')
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance/[Indexes for search performance].
 
 
-[[profile-queries]]
-== Profile queries
-
-link:https://neo4j.com/docs/cypher-manual/current/appendix/tutorials/basic-query-tuning/#_profile_query[*Profile your queries*] to locate queries whose performance can be improved.
-You can profile queries by prepending them with `PROFILE`.
-The server output is available in the `profile` property of the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, javascript, role=nocollapse]
-----
-const result = await driver.executeQuery('PROFILE MATCH (p {name: $name}) RETURN p', { name: 'Alice' })
-console.log(result.summary.profile.arguments['string-representation'])
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator        | Details        | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults | p              |              1 |    1 |       3 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter         | p.name = $name |              1 |    1 |       4 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +AllNodesScan   | p              |             10 |    4 |       5 |            120 |                 9160/0 |   108.923 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-
-Total database accesses: 12, total allocated memory: 184
-*/
-----
-
-In case some queries are so slow that you are unable to even run them in reasonable times, you can prepend them with `EXPLAIN` instead of `PROFILE`.
-This will return the _plan_ that the server would use to run the query, but without executing it.
-The server output is available in the `plan` property of the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, javascript, role=nocollapse]
-----
-const result = await driver.executeQuery('EXPLAIN MATCH (p {name: $name}) RETURN p', { name: 'Alice' })
-console.log(result.summary.plan.arguments['string-representation'])
-/*
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+---------------------+
-| Operator        | Details        | Estimated Rows | Pipeline            |
-+-----------------+----------------+----------------+---------------------+
-| +ProduceResults | p              |              1 |                     |
-| |               +----------------+----------------+                     |
-| +Filter         | p.name = $name |              1 |                     |
-| |               +----------------+----------------+                     |
-| +AllNodesScan   | p              |             10 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+---------------------+
-
-Total database accesses: ?
-*/
-----
+include::{common-partial}/performance.adoc[tag=profile-queries]
 
 
 [[node-labels]]

--- a/javascript-manual/modules/ROOT/pages/result-summary.adoc
+++ b/javascript-manual/modules/ROOT/pages/result-summary.adoc
@@ -85,6 +85,7 @@ Two additional methods on `ResultSummary.counters` act as meta-counters:
 - `.containsSystemUpdates()` -- whether the query triggered any write operation on the `system` database
 
 
+[#execution-plan]
 == Query execution plan
 
 If you prefix a query with `EXPLAIN`, the server returns the plan it _would_ use to run the query, but doesn't actually run it.

--- a/python-manual/modules/ROOT/pages/performance.adoc
+++ b/python-manual/modules/ROOT/pages/performance.adoc
@@ -300,64 +300,7 @@ driver.execute_query("CREATE INDEX person_name FOR (n:Person) ON (n.name)")
 For more information, see link:{neo4j-docs-base-uri}/cypher-manual/current/indexes-for-search-performance/[Indexes for search performance].
 
 
-[[profile-queries]]
-== Profile queries
-
-link:https://neo4j.com/docs/cypher-manual/current/appendix/tutorials/basic-query-tuning/#_profile_query[*Profile your queries*] to locate queries whose performance can be improved.
-You can profile queries by prepending them with `PROFILE`.
-The server output is available in the `profile` property of the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, python, role=nocollapse]
-----
-_, summary, _ = driver.execute_query("PROFILE MATCH (p {name: $name}) RETURN p", name="Alice")
-print(summary.profile['args']['string-representation'])
-"""
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator        | Details        | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults | p              |              1 |    1 |       3 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter         | p.name = $name |              1 |    1 |       4 |                |                        |           |                     |
-| |               +----------------+----------------+------+---------+----------------+                        |           |                     |
-| +AllNodesScan   | p              |             10 |    4 |       5 |            120 |                 9160/0 |   108.923 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-
-Total database accesses: 12, total allocated memory: 184
-"""
-----
-
-In case some queries are so slow that you are unable to even run them in reasonable times, you can prepend them with `EXPLAIN` instead of `PROFILE`.
-This will return the _plan_ that the server would use to run the query, but without executing it.
-The server output is available in the `plan` property of the xref:result-summary.adoc[`ResultSummary`] object.
-
-[source, python, role=nocollapse]
-----
-_, summary, _ = driver.execute_query("EXPLAIN MATCH (p {name: $name}) RETURN p", name="Alice")
-print(summary.plan['args']['string-representation'])
-"""
-Planner COST
-Runtime PIPELINED
-Runtime version 5.0
-Batch size 128
-
-+-----------------+----------------+----------------+---------------------+
-| Operator        | Details        | Estimated Rows | Pipeline            |
-+-----------------+----------------+----------------+---------------------+
-| +ProduceResults | p              |              1 |                     |
-| |               +----------------+----------------+                     |
-| +Filter         | p.name = $name |              1 |                     |
-| |               +----------------+----------------+                     |
-| +AllNodesScan   | p              |             10 | Fused in Pipeline 0 |
-+-----------------+----------------+----------------+---------------------+
-
-Total database accesses: ?
-"""
-----
+include::{common-partial}/performance.adoc[tag=profile-queries]
 
 
 [[node-labels]]

--- a/python-manual/modules/ROOT/pages/result-summary.adoc
+++ b/python-manual/modules/ROOT/pages/result-summary.adoc
@@ -67,6 +67,7 @@ Two additional boolean properties act as meta-counters:
 - `contains_system_updates` -- whether the query triggered any write operation on the `system` database
 
 
+[#execution-plan]
 == Query execution plan
 
 If you prefix a query with `EXPLAIN`, the server returns the plan it _would_ use to run the query, but doesn't actually run it.


### PR DESCRIPTION
The examples were duplicated and prone to get inaccurate if changes happened in that area, for no good reason.