### PR TITLE
DOCOPS-176 Add page-tabs attributes to driver component descriptors

### DIFF
--- a/dotnet-manual/antora.yml
+++ b/dotnet-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 18
+    page-tabs-group: drivers
     dotnet-driver-version: '6.3' # the version of the package published
     common-partial: 6@common-content:ROOT:partial$
     common-image: 6@common-content:ROOT:image$

--- a/go-manual/antora.yml
+++ b/go-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 12
+    page-tabs-group: drivers
     go-driver-version: '6.2' # the version of published go api docs
     common-partial: 6@common-content:ROOT:partial$
     common-image: 6@common-content:ROOT:image$

--- a/java-manual/antora.yml
+++ b/java-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 14
+    page-tabs-group: drivers
     java-driver-version: '6.1' # the version of the api docs
     java-driver-version-minor: '6.1.0' # the version of the package published at https://central.sonatype.com/artifact/org.neo4j.driver/neo4j-java-driver
     common-partial: 6@common-content:ROOT:partial$

--- a/javascript-manual/antora.yml
+++ b/javascript-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 16
+    page-tabs-group: drivers
     javascript-driver-version: '6.2' # the version of the api docs published at https://neo4j.com/docs/api/javascript-driver/
     common-partial: 6@common-content:ROOT:partial$
     common-image: 6@common-content:ROOT:image$

--- a/python-manual/antora.yml
+++ b/python-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 10
+    page-tabs-group: drivers
     python-driver-version: '6.0' # the version of the api docs published at https://neo4j.com/docs/api/python-driver/
     common-partial: 6@common-content:ROOT:partial$
     common-image: 6@common-content:ROOT:image$


### PR DESCRIPTION
Adds `page-tabs`, `page-tabs-index` and `page-tabs-group` to each driver manual's
`antora.yml`:

```yaml
asciidoc:
  attributes:
    page-tabs: drivers-apis@
    page-tabs-index: 10
    page-tabs-group: drivers
```

Places the driver manuals in the `drivers-apis` tab of the aggregated tabbed
navigation. Indexes are spaced 10, 12, 14, 16, 18 in the existing order (Python, Go,
Java, JavaScript, .NET), leaving gaps for further drivers.

These are set per component rather than in the publish playbook: a playbook carries a
single value for the whole build, which cannot order the five manuals within the tab.

`page-tabs-group` groups the driver manuals so that every published version is emitted
in the tab navigation and the UI can match it by version, rather than only the latest
version being included. This is why the same change is needed on each published
branch.

`page-tabs` is soft-set with a trailing `@` so it can be overridden.
