### PR TITLE
DOCOPS-176 Add page-tabs attributes to driver component descriptors

### DIFF
--- a/dotnet-manual/antora.yml
+++ b/dotnet-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 18
+    page-tabs-group: drivers
     dotnet-driver-version: '5.28' # the version of the package published
     dotnet-driver-version-minor: '5.28.4' # the version of the package published at https://www.nuget.org/packages/Neo4j.Driver
     common-partial: 5@common-content:ROOT:partial$

--- a/go-manual/antora.yml
+++ b/go-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 12
+    page-tabs-group: drivers
     go-driver-version: '5.28' # the version of published go api docs
     go-driver-apidoc-release: '5.0' # the github branch or release that contains examples included in docs
     go-examples: https://raw.githubusercontent.com/neo4j/neo4j-go-driver/{go-driver-apidoc-release}/tests/integration/examples

--- a/java-manual/antora.yml
+++ b/java-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 14
+    page-tabs-group: drivers
     java-driver-version: '5.28' # the version of the api docs
     java-driver-version-minor: '5.28.13' # the version of the package published at https://central.sonatype.com/artifact/org.neo4j.driver/neo4j-java-driver
     common-partial: 5@common-content:ROOT:partial$

--- a/javascript-manual/antora.yml
+++ b/javascript-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 16
+    page-tabs-group: drivers
     javascript-driver-version: '5.28' # the version of the api docs published at https://neo4j.com/docs/api/javascript-driver/
     javascript-driver-apidoc-release: '5.0' # the github branch or release that contains examples included in docs
     javascript-examples: https://raw.githubusercontent.com/neo4j/neo4j-javascript-driver/{javascript-driver-apidoc-release}/packages/neo4j-driver/test

--- a/python-manual/antora.yml
+++ b/python-manual/antora.yml
@@ -6,6 +6,9 @@ nav:
 - modules/ROOT/content-nav.adoc
 asciidoc:
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 10
+    page-tabs-group: drivers
     python-driver-version: '5.28' # the version of the api docs published at https://neo4j.com/docs/api/python-driver/
     python-driver-apidoc-release: '5.0' # the github branch or release that contains examples included in docs
     python-examples: https://raw.githubusercontent.com/neo4j/neo4j-python-driver/{python-driver-apidoc-release}/tests/integration/examples


### PR DESCRIPTION
Adds `page-tabs`, `page-tabs-index` and `page-tabs-group` to each driver manual's
`antora.yml`:

```yaml
asciidoc:
  attributes:
    page-tabs: drivers-apis@
    page-tabs-index: 10
    page-tabs-group: drivers
```

Places the driver manuals in the `drivers-apis` tab of the aggregated tabbed
navigation. Indexes are spaced 10, 12, 14, 16, 18 in the existing order (Python, Go,
Java, JavaScript, .NET), leaving gaps for further drivers.

These are set per component rather than in the publish playbook: a playbook carries a
single value for the whole build, which cannot order the five manuals within the tab.

`page-tabs-group` groups the driver manuals so that every published version is emitted
in the tab navigation and the UI can match it by version, rather than only the latest
version being included. This is why the same change is needed on each published
branch.

Same change as on `dev`, applied to this published branch.

`page-tabs` is soft-set with a trailing `@` so it can be overridden.
